### PR TITLE
[python] update python metamodel, add SHACL constraint

### DIFF
--- a/languages/python.json
+++ b/languages/python.json
@@ -3,8 +3,11 @@
         "xsd": "http://www.w3.org/2001/XMLSchema#",
         "py": "https://secorolab.github.io/metamodels/languages/python#",
 
-        "module": { "@id": "py:module", "@type": "xsd:string" },
-        "class-name": { "@id": "py:class-name", "@type": "xsd:string" },
+        "PyClass": { "@id": "py:Class" },
+        "PyModuleAttribute": { "@id": "py:ModuleAttribute" },
+        "module-name": { "@id": "py:module-name", "@type": "xsd:string" },
+        "attribute-name": { "@id": "py:attribute-name", "@type": "xsd:string" },
+
         "ArgValue": { "@id": "py:ArgValue" },
         "ArgName": { "@id": "py:ArgName", "@type": "xsd:string" }
     }

--- a/languages/python.shacl.ttl
+++ b/languages/python.shacl.ttl
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Author: Minh Nguyen (minh@mail.minhnh.com)
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix py: <https://secorolab.github.io/metamodels/languages/python#> .
+
+py:ModuleAttributeShape
+    a sh:NodeShape ;
+    sh:property [
+        sh:path py:module-name ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+    ] ;
+    sh:property [
+        sh:path py:attribute-name ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+    ] .


### PR DESCRIPTION
- change concepts to be more general, i.e. for all attributes of a module instead of just classes
- add SHACL constraint for Python MM
- this is meant to work with python module under [minhnh/rdf-utils](https://github.com/minhnh/rdf-utils)