### PR TITLE
add metamodel and shacl constraint for event loops

### DIFF
--- a/behaviour/event_loop.json
+++ b/behaviour/event_loop.json
@@ -1,0 +1,20 @@
+{
+    "@context": {
+        "el": "https://secorolab.github.io/metamodels/behaviour/event_loop#",
+        "EventLoop": { "@id": "el:EventLoop" },
+
+        "Event": { "@id": "el:Event" },
+        "has-event": { "@id": "el:has-event", "@type": "@id" },
+        "ref-event": { "@id": "el:ref-event", "@type": "@id" },
+
+        "Flag": { "@id": "el:Flag" },
+        "has-flag": { "@id": "el:has-flag", "@type": "@id" },
+        "ref-flag": { "@id": "el:ref-flag", "@type": "@id" },
+
+        "EventReaction": { "@id": "el:EventReaction" },
+        "has-evt-reaction": { "@id": "el:has-evt-reaction", "@type": "@id" },
+
+        "FlagReaction": { "@id": "el:FlagReaction" },
+        "has-flg-reaction": { "@id": "el:has-flg-reaction", "@type": "@id" }
+    }
+}

--- a/behaviour/event_loop.shacl.ttl
+++ b/behaviour/event_loop.shacl.ttl
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Author: Minh Nguyen (minh@mail.minhnh.com)
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix el: <https://secorolab.github.io/metamodels/behaviour/event_loop#> .
+
+el:RefEventShape
+  a sh:PropertyShape ;
+  sh:description ":ref-event must link to exactly 1 :Event" ;
+  sh:path el:ref-event ;
+  sh:class el:Event ;
+  sh:minCount 1 ;
+  sh:maxCount 1 .
+
+el:RefFlagShape
+  a sh:PropertyShape ;
+  sh:description ":ref-flag must link to exactly 1 :Flag" ;
+  sh:path el:ref-flag ;
+  sh:class el:Flag ;
+  sh:minCount 1 ;
+  sh:maxCount 1 .
+
+el:EventLoopShape
+  a sh:NodeShape ;
+  sh:targetClass el:EventLoop ;
+  sh:property [
+    sh:path el:has-event ;
+    sh:class el:Event ;
+    sh:minCount 0 ;
+  ] ;
+  sh:property [
+    sh:path el:has-flag ;
+    sh:class el:Flag ;
+    sh:minCount 0 ;
+  ] ;
+  sh:property [
+    sh:path el:has-evt-reaction ;
+    sh:class el:EventReaction ;
+    sh:minCount 0 ;
+  ] ;
+  sh:property [
+    sh:path el:has-flg-reaction ;
+    sh:class el:FlagReaction ;
+    sh:minCount 0 ;
+  ] .
+
+el:EventReactionShape
+  a sh:NodeShape ;
+  sh:targetClass el:EventReaction ;
+  sh:property el:RefEventShape .
+
+el:FlagReactionShape
+  a sh:NodeShape ;
+  sh:targetClass el:FlagReaction ;
+  sh:property el:RefFlagShape .


### PR DESCRIPTION
- Add concepts for event, flag, event loop, and predicates for referring to flags and events, where `has-*` predicates are for referring to "1-or-more" and `ref-*` for exactly 1 element.
- Choice: separate `EventReaction` and `FlagReaction` to simplify queries.
- Add SHACL constraint for composition of event loop concepts (tested in secorolab/rdf-utils#1).
- resolve #6 