### PR TITLE
Add coordinates property

### DIFF
--- a/geometry/coordinates.json
+++ b/geometry/coordinates.json
@@ -28,6 +28,10 @@
         "gamma": {
             "@id": "geom-coord:gamma",
             "@type": "xsd:double"
+        },
+        "coordinates": {
+            "@id": "geom-coord:coordinates",
+            "@container": "@list"
         }
     }
 }


### PR DESCRIPTION
This is needed (at least for now) for the IFC conversion, and meant to replace the `x`, `y` and `z` values.  Example on the converted IFC (I'm omitting some things for simplicity):

```json
    {
      "@id": "ifc-model:1195",
      "@type": "ifc:IFCCARTESIANPOINT",
      "coordinates": [0.0, 0.0, 0.0]
    }
```

This becomes in FPM:

```json
    {
      "@id": "pose-coord-wall-1279",
      "@type": ["PoseReference", "PoseCoordinate", "DirectionCosineXYZ", "VectorXYZ"],
      "of-pose": "pose-wall-1279",
      "as-seen-by": "placement-2010-frame",
      "unit": ["UNITLESS", "M"],
      "direction-cosine-x": [1.0, 0.0, 0.0],
      "direction-cosine-z": [0.0, 0.0, 1.0],
      "coordinates": [0.0, 0.0, 0.0]
    }
```