### PR TITLE
add metamodels required for sercoro website content

### DIFF
--- a/website/news.json
+++ b/website/news.json
@@ -1,0 +1,24 @@
+{
+    "@context": {
+        "xsd": "http://www.w3.org/2001/XMLSchema#",
+        "news": "https://secorolab.github.io/metamodels/website/news#",
+
+        "NewsArticle": { "@id": "news:NewsArticle" },
+
+        "name":           { "@id": "news:name",           "@type": "xsd:string" },
+        "description":    { "@id": "news:description",    "@type": "xsd:string" },
+        "date-published": { "@id": "news:date-published", "@type": "xsd:date" },
+        "url":            { "@id": "news:url",            "@type": "@id" },
+
+        "about": {
+            "@id":        "news:about",
+            "@type":      "@id",
+            "@container": "@list"
+        },
+
+        "keywords": {
+            "@id":        "news:keywords",
+            "@container": "@list"
+        }
+    }
+}

--- a/website/news.json
+++ b/website/news.json
@@ -13,12 +13,12 @@
         "about": {
             "@id":        "news:about",
             "@type":      "@id",
-            "@container": "@list"
+            "@container": "@set"
         },
 
         "keywords": {
             "@id":        "news:keywords",
-            "@container": "@list"
+            "@container": "@set"
         }
     }
 }

--- a/website/news.ttl
+++ b/website/news.ttl
@@ -1,0 +1,52 @@
+@prefix sh:     <http://www.w3.org/ns/shacl#> .
+@prefix xsd:    <http://www.w3.org/2001/XMLSchema#> .
+@prefix sh_sec: <https://secorolab.github.io/metamodels/website/> .
+@prefix news:   <https://secorolab.github.io/metamodels/website/news#> .
+
+sh_sec:NewsShape
+    a sh:NodeShape ;
+    sh:targetClass news:NewsArticle ;
+    sh:closed false ;
+
+    sh:property [
+        sh:path     news:name ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:minLength 3 ;
+        sh:severity sh:Violation ;
+        sh:message  "News article must have a title." ;
+    ] ;
+
+    sh:property [
+        sh:path     news:description ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:severity sh:Warning ;
+        sh:message  "News article should have a description." ;
+    ] ;
+
+    sh:property [
+        sh:path     news:date-published ;
+        sh:datatype xsd:date ;
+        sh:maxCount 1 ;
+        sh:severity sh:Warning ;
+        sh:message  "date-published should be a valid xsd:date." ;
+    ] ;
+
+    sh:property [
+        sh:path     news:url ;
+        sh:nodeKind sh:IRI ;
+        sh:maxCount 1 ;
+    ] ;
+
+    sh:property [
+        sh:path     news:about ;
+        sh:nodeKind sh:IRI ;
+    ] ;
+
+    sh:property [
+        sh:path     news:keywords ;
+        sh:datatype xsd:string ;
+    ] ;
+.

--- a/website/opening.json
+++ b/website/opening.json
@@ -24,7 +24,7 @@
 
         "applicant-location-requirements": {
             "@id":        "opening:applicant-location-requirements",
-            "@container": "@list"
+            "@container": "@set"
         }
     }
 }

--- a/website/opening.json
+++ b/website/opening.json
@@ -1,0 +1,30 @@
+{
+    "@context": {
+        "xsd": "http://www.w3.org/2001/XMLSchema#",
+        "opening": "https://secorolab.github.io/metamodels/website/opening#",
+
+        "JobPosting":    { "@id": "opening:JobPosting" },
+        "Organization":  { "@id": "opening:Organization" },
+
+        "title":               { "@id": "opening:title",               "@type": "xsd:string" },
+        "description":         { "@id": "opening:description",         "@type": "xsd:string" },
+        "employment-type":     { "@id": "opening:employment-type",     "@type": "xsd:string" },
+        "qualifications":      { "@id": "opening:qualifications",      "@type": "xsd:string" },
+        "responsibilities":    { "@id": "opening:responsibilities",    "@type": "xsd:string" },
+        "skills":              { "@id": "opening:skills",              "@type": "xsd:string" },
+        "incentive-compensation": { "@id": "opening:incentive-compensation", "@type": "xsd:string" },
+        "date-posted":         { "@id": "opening:date-posted",         "@type": "xsd:date" },
+        "valid-through":       { "@id": "opening:valid-through",       "@type": "xsd:date" },
+
+        "hiring-organization": { "@id": "opening:hiring-organization", "@type": "@id" },
+        "job-location":        { "@id": "opening:job-location",        "@type": "@id" },
+
+        "org-name": { "@id": "opening:org-name", "@type": "xsd:string" },
+        "org-url":  { "@id": "opening:org-url",  "@type": "@id" },
+
+        "applicant-location-requirements": {
+            "@id":        "opening:applicant-location-requirements",
+            "@container": "@list"
+        }
+    }
+}

--- a/website/opening.ttl
+++ b/website/opening.ttl
@@ -1,0 +1,119 @@
+@prefix sh:      <http://www.w3.org/ns/shacl#> .
+@prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
+@prefix sh_sec:  <https://secorolab.github.io/metamodels/website/> .
+@prefix opening: <https://secorolab.github.io/metamodels/website/opening#> .
+
+sh_sec:OpeningShape
+    a sh:NodeShape ;
+    sh:targetClass opening:JobPosting ;
+    sh:closed false ;
+
+    sh:property [
+        sh:path     opening:title ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:minLength 3 ;
+        sh:severity sh:Violation ;
+        sh:message  "Job posting must have a title." ;
+    ] ;
+
+    sh:property [
+        sh:path     opening:description ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:severity sh:Violation ;
+        sh:message  "Job posting must have a description." ;
+    ] ;
+
+    sh:property [
+        sh:path     opening:employment-type ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:in       ( "HiWi" "PhD" "PostDoc" "FullTime" "PartTime" "Internship" "Volunteer" "MSc Thesis" "BSc Thesis" ) ;
+        sh:severity sh:Warning ;
+        sh:message  "employment-type should be a recognised type." ;
+    ] ;
+
+    sh:property [
+        sh:path     opening:date-posted ;
+        sh:datatype xsd:date ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:severity sh:Violation ;
+        sh:message  "Job posting must have a date-posted." ;
+    ] ;
+
+    sh:property [
+        sh:path     opening:valid-through ;
+        sh:datatype xsd:date ;
+        sh:maxCount 1 ;
+        sh:severity sh:Warning ;
+        sh:message  "valid-through should be a valid xsd:date." ;
+    ] ;
+
+    sh:property [
+        sh:path     opening:qualifications ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+    ] ;
+
+    sh:property [
+        sh:path     opening:responsibilities ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+    ] ;
+
+    sh:property [
+        sh:path     opening:skills ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+    ] ;
+
+    sh:property [
+        sh:path     opening:incentive-compensation ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+    ] ;
+
+    sh:property [
+        sh:path     opening:hiring-organization ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:maxCount 1 ;
+        sh:severity sh:Warning ;
+        sh:message  "Job posting should reference a hiring-organization." ;
+    ] ;
+
+    sh:property [
+        sh:path     opening:job-location ;
+        sh:nodeKind sh:IRI ;
+        sh:maxCount 1 ;
+    ] ;
+
+    sh:property [
+        sh:path     opening:applicant-location-requirements ;
+        sh:datatype xsd:string ;
+    ] ;
+.
+
+sh_sec:OrganizationShape
+    a sh:NodeShape ;
+    sh:targetClass opening:Organization ;
+    sh:closed false ;
+
+    sh:property [
+        sh:path     opening:org-name ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:severity sh:Violation ;
+        sh:message  "Organisation must have a name." ;
+    ] ;
+
+    sh:property [
+        sh:path     opening:org-url ;
+        sh:nodeKind sh:IRI ;
+        sh:maxCount 1 ;
+    ] ;
+.

--- a/website/person.json
+++ b/website/person.json
@@ -3,29 +3,33 @@
         "xsd": "http://www.w3.org/2001/XMLSchema#",
         "person": "https://secorolab.github.io/metamodels/website/person#",
 
-        "Person":     { "@id": "person:Person" },
+        "Person":       { "@id": "person:Person" },
 
-        "name":       { "@id": "person:name",      "@type": "xsd:string" },
-        "job-title":  { "@id": "person:job-title", "@type": "xsd:string" },
-        "email":      { "@id": "person:email",     "@type": "xsd:string" },
-        "url":        { "@id": "person:url",       "@type": "@id" },
-        "orcid":      { "@id": "person:orcid",     "@type": "@id" },
-        "g-scholar":  { "@id": "person:g-scholar", "@type": "@id" },
-        "linkedin":   { "@id": "person:linkedin",  "@type": "@id" },
-        "github":     { "@id": "person:github",    "@type": "@id" },
-        "twitter":    { "@id": "person:twitter",   "@type": "@id" },
-        "image":      { "@id": "person:image",     "@type": "@id" },
+        "first-name":   { "@id": "person:first-name",  "@type": "xsd:string" },
+        "last-name":    { "@id": "person:last-name",   "@type": "xsd:string" },
+        "middle-name":  { "@id": "person:middle-name", "@type": "xsd:string" },
+        "job-title":    { "@id": "person:job-title",   "@type": "xsd:string" },
+        "email":        { "@id": "person:email",       "@type": "xsd:string" },
+        "url":          { "@id": "person:url",         "@type": "@id" },
+        "orcid":        { "@id": "person:orcid",       "@type": "@id" },
+        "g-scholar":    { "@id": "person:g-scholar",   "@type": "@id" },
+        "linkedin":     { "@id": "person:linkedin",    "@type": "@id" },
+        "github":       { "@id": "person:github",      "@type": "@id" },
+        "twitter":      { "@id": "person:twitter",     "@type": "@id" },
+        "image":        { "@id": "person:image",       "@type": "@id" },
+        "start-date":   { "@id": "person:start-date",  "@type": "xsd:date" },
+        "end-date":     { "@id": "person:end-date",    "@type": "xsd:date" },
 
-        "same-as": {
-            "@id":        "person:same-as",
-            "@type":      "@id",
-            "@container": "@list"
+        "name-alias": {
+            "@id":        "person:name-alias",
+            "@type":      "xsd:string",
+            "@container": "@set"
         },
 
         "knows-about": {
             "@id":        "person:knows-about",
             "@type":      "@id",
-            "@container": "@list"
+            "@container": "@set"
         }
     }
 }

--- a/website/person.json
+++ b/website/person.json
@@ -1,0 +1,31 @@
+{
+    "@context": {
+        "xsd": "http://www.w3.org/2001/XMLSchema#",
+        "person": "https://secorolab.github.io/metamodels/website/person#",
+
+        "Person":     { "@id": "person:Person" },
+
+        "name":       { "@id": "person:name",      "@type": "xsd:string" },
+        "job-title":  { "@id": "person:job-title", "@type": "xsd:string" },
+        "email":      { "@id": "person:email",     "@type": "xsd:string" },
+        "url":        { "@id": "person:url",       "@type": "@id" },
+        "orcid":      { "@id": "person:orcid",     "@type": "@id" },
+        "g-scholar":  { "@id": "person:g-scholar", "@type": "@id" },
+        "linkedin":   { "@id": "person:linkedin",  "@type": "@id" },
+        "github":     { "@id": "person:github",    "@type": "@id" },
+        "twitter":    { "@id": "person:twitter",   "@type": "@id" },
+        "image":      { "@id": "person:image",     "@type": "@id" },
+
+        "same-as": {
+            "@id":        "person:same-as",
+            "@type":      "@id",
+            "@container": "@list"
+        },
+
+        "knows-about": {
+            "@id":        "person:knows-about",
+            "@type":      "@id",
+            "@container": "@list"
+        }
+    }
+}

--- a/website/person.ttl
+++ b/website/person.ttl
@@ -1,0 +1,117 @@
+@prefix sh:     <http://www.w3.org/ns/shacl#> .
+@prefix xsd:    <http://www.w3.org/2001/XMLSchema#> .
+@prefix sh_sec: <https://secorolab.github.io/metamodels/website/> .
+@prefix person: <https://secorolab.github.io/metamodels/website/person#> .
+
+sh_sec:PersonShape
+    a sh:NodeShape ;
+    sh:targetClass person:Person ;
+    sh:closed false ;
+
+    sh:property [
+        sh:path     person:first-name ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:minLength 1 ;
+        sh:severity sh:Violation ;
+        sh:message  "Person must have exactly one first name." ;
+    ] ;
+
+    sh:property [
+        sh:path     person:last-name ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:minLength 1 ;
+        sh:severity sh:Violation ;
+        sh:message  "Person must have exactly one last name." ;
+    ] ;
+
+    sh:property [
+        sh:path     person:middle-name ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+    ] ;
+
+    sh:property [
+        sh:path     person:job-title ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+    ] ;
+
+    sh:property [
+        sh:path     person:email ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:pattern  "^$|^[^@\\s]+@[^@\\s]+\\.[^@\\s]+$" ;
+        sh:severity sh:Warning ;
+        sh:message  "Email should be a valid address or empty string." ;
+    ] ;
+
+    sh:property [
+        sh:path     person:url ;
+        sh:nodeKind sh:IRI ;
+        sh:maxCount 1 ;
+    ] ;
+
+    sh:property [
+        sh:path     person:orcid ;
+        sh:nodeKind sh:IRI ;
+        sh:maxCount 1 ;
+    ] ;
+
+    sh:property [
+        sh:path     person:g-scholar ;
+        sh:nodeKind sh:IRI ;
+        sh:maxCount 1 ;
+    ] ;
+
+    sh:property [
+        sh:path     person:linkedin ;
+        sh:nodeKind sh:IRI ;
+        sh:maxCount 1 ;
+    ] ;
+
+    sh:property [
+        sh:path     person:github ;
+        sh:nodeKind sh:IRI ;
+        sh:maxCount 1 ;
+    ] ;
+
+    sh:property [
+        sh:path     person:twitter ;
+        sh:nodeKind sh:IRI ;
+        sh:maxCount 1 ;
+    ] ;
+
+    sh:property [
+        sh:path     person:image ;
+        sh:nodeKind sh:IRI ;
+        sh:maxCount 1 ;
+    ] ;
+
+    sh:property [
+        sh:path     person:start-date ;
+        sh:datatype xsd:date ;
+        sh:maxCount 1 ;
+    ] ;
+
+    sh:property [
+        sh:path     person:end-date ;
+        sh:datatype xsd:date ;
+        sh:maxCount 1 ;
+    ] ;
+
+    sh:property [
+        sh:path     person:name-alias ;
+        sh:datatype xsd:string ;
+    ] ;
+
+    sh:property [
+        sh:path     person:knows-about ;
+        sh:class    <https://secorolab.github.io/metamodels/website/research-area#ResearchArea> ;
+        sh:severity sh:Warning ;
+        sh:message  "knows-about should reference a research-area:ResearchArea." ;
+    ] ;
+.

--- a/website/project.json
+++ b/website/project.json
@@ -1,0 +1,26 @@
+{
+    "@context": {
+        "xsd": "http://www.w3.org/2001/XMLSchema#",
+        "project": "https://secorolab.github.io/metamodels/website/project#",
+
+        "Project":      { "@id": "project:Project" },
+        "FunderOrg":    { "@id": "project:FunderOrg" },
+
+        "name":        { "@id": "project:name",        "@type": "xsd:string" },
+        "description": { "@id": "project:description", "@type": "xsd:string" },
+        "start-date":  { "@id": "project:start-date",  "@type": "xsd:date" },
+        "end-date":    { "@id": "project:end-date",    "@type": "xsd:date" },
+        "url":         { "@id": "project:url",         "@type": "@id" },
+
+        "funder": { "@id": "project:funder", "@type": "@id" },
+
+        "funder-name": { "@id": "project:funder-name", "@type": "xsd:string" },
+        "funder-url":  { "@id": "project:funder-url",  "@type": "@id" },
+
+        "member": {
+            "@id":        "project:member",
+            "@type":      "@id",
+            "@container": "@list"
+        }
+    }
+}

--- a/website/project.json
+++ b/website/project.json
@@ -20,7 +20,7 @@
         "member": {
             "@id":        "project:member",
             "@type":      "@id",
-            "@container": "@list"
+            "@container": "@set"
         }
     }
 }

--- a/website/project.ttl
+++ b/website/project.ttl
@@ -1,0 +1,82 @@
+@prefix sh:      <http://www.w3.org/ns/shacl#> .
+@prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
+@prefix sh_sec:  <https://secorolab.github.io/metamodels/website/> .
+@prefix project: <https://secorolab.github.io/metamodels/website/project#> .
+
+sh_sec:ProjectShape
+    a sh:NodeShape ;
+    sh:targetClass project:Project ;
+    sh:closed false ;
+
+    sh:property [
+        sh:path     project:name ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:minLength 2 ;
+        sh:severity sh:Violation ;
+        sh:message  "Project must have a name." ;
+    ] ;
+
+    sh:property [
+        sh:path     project:description ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:severity sh:Warning ;
+        sh:message  "Project should have a description." ;
+    ] ;
+
+    sh:property [
+        sh:path     project:url ;
+        sh:nodeKind sh:IRI ;
+        sh:maxCount 1 ;
+    ] ;
+
+    sh:property [
+        sh:path     project:start-date ;
+        sh:datatype xsd:date ;
+        sh:maxCount 1 ;
+        sh:severity sh:Warning ;
+        sh:message  "start-date should be a valid xsd:date." ;
+    ] ;
+
+    sh:property [
+        sh:path     project:end-date ;
+        sh:datatype xsd:date ;
+        sh:maxCount 1 ;
+        sh:severity sh:Warning ;
+        sh:message  "end-date should be a valid xsd:date." ;
+    ] ;
+
+    sh:property [
+        sh:path     project:funder ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:maxCount 1 ;
+    ] ;
+
+    sh:property [
+        sh:path     project:member ;
+        sh:nodeKind sh:IRI ;
+    ] ;
+.
+
+sh_sec:FunderOrgShape
+    a sh:NodeShape ;
+    sh:targetClass project:FunderOrg ;
+    sh:closed false ;
+
+    sh:property [
+        sh:path     project:funder-name ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:severity sh:Violation ;
+        sh:message  "Funder organisation must have a name." ;
+    ] ;
+
+    sh:property [
+        sh:path     project:funder-url ;
+        sh:nodeKind sh:IRI ;
+        sh:maxCount 1 ;
+    ] ;
+.

--- a/website/publication.json
+++ b/website/publication.json
@@ -1,0 +1,32 @@
+{
+    "@context": {
+        "xsd": "http://www.w3.org/2001/XMLSchema#",
+        "publication": "https://secorolab.github.io/metamodels/website/publication#",
+
+        "Publication": { "@id": "publication:Publication" },
+        "Venue":       { "@id": "publication:Venue" },
+        "PersonRef":   { "@id": "publication:PersonRef" },
+
+        "name":           { "@id": "publication:name",           "@type": "xsd:string" },
+        "date-published": { "@id": "publication:date-published", "@type": "xsd:date" },
+        "url":            { "@id": "publication:url",            "@type": "@id" },
+        "doi":            { "@id": "publication:doi",            "@type": "@id" },
+        "same-as":        { "@id": "publication:same-as",        "@type": "@id" },
+
+        "venue-name": { "@id": "publication:venue-name", "@type": "xsd:string" },
+
+        "author": {
+            "@id":        "publication:author",
+            "@type":      "@id",
+            "@container": "@set"
+        },
+
+        "is-part-of": { "@id": "publication:is-part-of", "@type": "@id" },
+
+        "about": {
+            "@id":        "publication:about",
+            "@type":      "@id",
+            "@container": "@list"
+        }
+    }
+}

--- a/website/publication.json
+++ b/website/publication.json
@@ -11,7 +11,7 @@
         "date-published": { "@id": "publication:date-published", "@type": "xsd:date" },
         "url":            { "@id": "publication:url",            "@type": "@id" },
         "doi":            { "@id": "publication:doi",            "@type": "@id" },
-        "same-as":        { "@id": "publication:same-as",        "@type": "@id" },
+        "external-url":   { "@id": "publication:external-url",   "@type": "@id" },
 
         "venue-name": { "@id": "publication:venue-name", "@type": "xsd:string" },
 
@@ -26,7 +26,7 @@
         "about": {
             "@id":        "publication:about",
             "@type":      "@id",
-            "@container": "@list"
+            "@container": "@set"
         }
     }
 }

--- a/website/publication.ttl
+++ b/website/publication.ttl
@@ -1,0 +1,103 @@
+@prefix sh:          <http://www.w3.org/ns/shacl#> .
+@prefix xsd:         <http://www.w3.org/2001/XMLSchema#> .
+@prefix sh_sec:      <https://secorolab.github.io/metamodels/website/> .
+@prefix publication: <https://secorolab.github.io/metamodels/website/publication#> .
+
+sh_sec:PublicationShape
+    a sh:NodeShape ;
+    sh:targetClass publication:Publication ;
+    sh:closed false ;
+
+    sh:property [
+        sh:path     publication:name ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:minLength 5 ;
+        sh:severity sh:Violation ;
+        sh:message  "Publication must have a title." ;
+    ] ;
+
+    sh:property [
+        sh:path     publication:author ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:minCount 1 ;
+        sh:severity sh:Violation ;
+        sh:message  "Publication must have at least one author." ;
+    ] ;
+
+    sh:property [
+        sh:path     publication:date-published ;
+        sh:datatype xsd:date ;
+        sh:maxCount 1 ;
+        sh:severity sh:Warning ;
+        sh:message  "date-published should be a valid xsd:date." ;
+    ] ;
+
+    sh:property [
+        sh:path     publication:url ;
+        sh:nodeKind sh:IRI ;
+        sh:maxCount 1 ;
+    ] ;
+
+    sh:property [
+        sh:path     publication:doi ;
+        sh:nodeKind sh:IRI ;
+        sh:maxCount 1 ;
+    ] ;
+
+    sh:property [
+        sh:path     publication:external-url ;
+        sh:nodeKind sh:IRI ;
+        sh:maxCount 1 ;
+    ] ;
+
+    sh:property [
+        sh:path     publication:is-part-of ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:maxCount 1 ;
+        sh:severity sh:Warning ;
+        sh:message  "Publication should reference a venue via is-part-of." ;
+    ] ;
+
+    sh:property [
+        sh:path     publication:about ;
+        sh:nodeKind sh:IRI ;
+    ] ;
+.
+
+sh_sec:VenueShape
+    a sh:NodeShape ;
+    sh:targetClass publication:Venue ;
+    sh:closed false ;
+
+    sh:property [
+        sh:path     publication:venue-name ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:severity sh:Violation ;
+        sh:message  "Venue must have a name." ;
+    ] ;
+
+    sh:property [
+        sh:path     publication:url ;
+        sh:nodeKind sh:IRI ;
+        sh:maxCount 1 ;
+    ] ;
+.
+
+sh_sec:PublicationPersonRefShape
+    a sh:NodeShape ;
+    sh:targetClass publication:PersonRef ;
+    sh:closed false ;
+
+    sh:property [
+        sh:path     publication:name ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:severity sh:Violation ;
+        sh:message  "Author reference must have a name." ;
+    ] ;
+.

--- a/website/research-area.json
+++ b/website/research-area.json
@@ -1,0 +1,12 @@
+{
+    "@context": {
+        "xsd": "http://www.w3.org/2001/XMLSchema#",
+        "research-area": "https://secorolab.github.io/metamodels/website/research-area#",
+
+        "ResearchArea": { "@id": "research-area:ResearchArea" },
+
+        "name":        { "@id": "research-area:name",        "@type": "xsd:string" },
+        "description": { "@id": "research-area:description", "@type": "xsd:string" },
+        "term-code":   { "@id": "research-area:term-code",   "@type": "xsd:string" }
+    }
+}

--- a/website/research.ttl
+++ b/website/research.ttl
@@ -1,0 +1,37 @@
+@prefix sh:            <http://www.w3.org/ns/shacl#> .
+@prefix xsd:           <http://www.w3.org/2001/XMLSchema#> .
+@prefix sh_sec:        <https://secorolab.github.io/metamodels/website/> .
+@prefix research-area: <https://secorolab.github.io/metamodels/website/research-area#> .
+
+sh_sec:ResearchAreaShape
+    a sh:NodeShape ;
+    sh:targetClass research-area:ResearchArea ;
+    sh:closed false ;
+
+    sh:property [
+        sh:path     research-area:name ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:minLength 3 ;
+        sh:severity sh:Violation ;
+        sh:message  "Research area must have exactly one name." ;
+    ] ;
+
+    sh:property [
+        sh:path     research-area:description ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:severity sh:Warning ;
+        sh:message  "Research area should have a description." ;
+    ] ;
+
+    sh:property [
+        sh:path     research-area:term-code ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:pattern  "^[a-z0-9]+(-[a-z0-9]+)*$" ;
+        sh:severity sh:Warning ;
+        sh:message  "term-code should be a lowercase hyphenated slug." ;
+    ] ;
+.

--- a/website/robot.json
+++ b/website/robot.json
@@ -1,0 +1,20 @@
+{
+    "@context": {
+        "xsd": "http://www.w3.org/2001/XMLSchema#",
+        "robot": "https://secorolab.github.io/metamodels/website/robot#",
+
+        "Robot": { "@id": "robot:Robot" },
+        "Brand": { "@id": "robot:Brand" },
+
+        "name":        { "@id": "robot:name",        "@type": "xsd:string" },
+        "description": { "@id": "robot:description", "@type": "xsd:string" },
+        "image":       { "@id": "robot:image",       "@type": "@id" },
+        "url":         { "@id": "robot:url",         "@type": "@id" },
+        "model":       { "@id": "robot:model",       "@type": "xsd:string" },
+        "weight":      { "@id": "robot:weight",      "@type": "xsd:string" },
+
+        "brand":        { "@id": "robot:brand",        "@type": "@id" },
+        "brand-name":   { "@id": "robot:brand-name",   "@type": "xsd:string" },
+        "manufacturer": { "@id": "robot:manufacturer", "@type": "@id" }
+    }
+}

--- a/website/robot.ttl
+++ b/website/robot.ttl
@@ -1,0 +1,79 @@
+@prefix sh:     <http://www.w3.org/ns/shacl#> .
+@prefix xsd:    <http://www.w3.org/2001/XMLSchema#> .
+@prefix sh_sec: <https://secorolab.github.io/metamodels/website/> .
+@prefix robot:  <https://secorolab.github.io/metamodels/website/robot#> .
+
+sh_sec:RobotShape
+    a sh:NodeShape ;
+    sh:targetClass robot:Robot ;
+    sh:closed false ;
+
+    sh:property [
+        sh:path     robot:name ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:minLength 2 ;
+        sh:severity sh:Violation ;
+        sh:message  "Robot must have a name." ;
+    ] ;
+
+    sh:property [
+        sh:path     robot:description ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:severity sh:Warning ;
+        sh:message  "Robot should have a description." ;
+    ] ;
+
+    sh:property [
+        sh:path     robot:image ;
+        sh:nodeKind sh:IRI ;
+        sh:maxCount 1 ;
+    ] ;
+
+    sh:property [
+        sh:path     robot:url ;
+        sh:nodeKind sh:IRI ;
+        sh:maxCount 1 ;
+    ] ;
+
+    sh:property [
+        sh:path     robot:model ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+    ] ;
+
+    sh:property [
+        sh:path     robot:weight ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+    ] ;
+
+    sh:property [
+        sh:path     robot:brand ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:maxCount 1 ;
+    ] ;
+
+    sh:property [
+        sh:path     robot:manufacturer ;
+        sh:nodeKind sh:IRI ;
+        sh:maxCount 1 ;
+    ] ;
+.
+
+sh_sec:BrandShape
+    a sh:NodeShape ;
+    sh:targetClass robot:Brand ;
+    sh:closed false ;
+
+    sh:property [
+        sh:path     robot:brand-name ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:severity sh:Violation ;
+        sh:message  "Brand must have a name." ;
+    ] ;
+.

--- a/website/thesis.json
+++ b/website/thesis.json
@@ -1,0 +1,26 @@
+{
+    "@context": {
+        "xsd": "http://www.w3.org/2001/XMLSchema#",
+        "thesis": "https://secorolab.github.io/metamodels/website/thesis#",
+
+        "Thesis":    { "@id": "thesis:Thesis" },
+        "PersonRef": { "@id": "thesis:PersonRef" },
+
+        "name":              { "@id": "thesis:name",              "@type": "xsd:string" },
+        "description":       { "@id": "thesis:description",       "@type": "xsd:string" },
+        "date-published":    { "@id": "thesis:date-published",    "@type": "xsd:date" },
+        "educational-level": { "@id": "thesis:educational-level", "@type": "xsd:string" },
+        "in-support-of":     { "@id": "thesis:in-support-of",     "@type": "xsd:string" },
+        "url":               { "@id": "thesis:url",               "@type": "@id" },
+
+        "author": { "@id": "thesis:author", "@type": "@id" },
+
+        "advisor": {
+            "@id":        "thesis:advisor",
+            "@type":      "@id",
+            "@container": "@list"
+        },
+
+        "source-organization": { "@id": "thesis:source-organization", "@type": "@id" }
+    }
+}

--- a/website/thesis.json
+++ b/website/thesis.json
@@ -18,7 +18,7 @@
         "advisor": {
             "@id":        "thesis:advisor",
             "@type":      "@id",
-            "@container": "@list"
+            "@container": "@set"
         },
 
         "source-organization": { "@id": "thesis:source-organization", "@type": "@id" }

--- a/website/thesis.ttl
+++ b/website/thesis.ttl
@@ -1,0 +1,90 @@
+@prefix sh:     <http://www.w3.org/ns/shacl#> .
+@prefix xsd:    <http://www.w3.org/2001/XMLSchema#> .
+@prefix sh_sec: <https://secorolab.github.io/metamodels/website/> .
+@prefix thesis: <https://secorolab.github.io/metamodels/website/thesis#> .
+
+sh_sec:ThesisShape
+    a sh:NodeShape ;
+    sh:targetClass thesis:Thesis ;
+    sh:closed false ;
+
+    sh:property [
+        sh:path     thesis:name ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:minLength 5 ;
+        sh:severity sh:Violation ;
+        sh:message  "Thesis must have a title." ;
+    ] ;
+
+    sh:property [
+        sh:path     thesis:author ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:severity sh:Violation ;
+        sh:message  "Thesis must have exactly one author." ;
+    ] ;
+
+    sh:property [
+        sh:path     thesis:date-published ;
+        sh:datatype xsd:date ;
+        sh:maxCount 1 ;
+        sh:severity sh:Warning ;
+        sh:message  "date-published should be a valid xsd:date." ;
+    ] ;
+
+    sh:property [
+        sh:path     thesis:educational-level ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:in       ( "PhD" "MSc" "BSc" "Master" "Bachelor" "Doctoral" ) ;
+        sh:severity sh:Warning ;
+        sh:message  "educational-level should be one of: PhD, MSc, BSc, Master, Bachelor, Doctoral." ;
+    ] ;
+
+    sh:property [
+        sh:path     thesis:in-support-of ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+    ] ;
+
+    sh:property [
+        sh:path     thesis:description ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+    ] ;
+
+    sh:property [
+        sh:path     thesis:url ;
+        sh:nodeKind sh:IRI ;
+        sh:maxCount 1 ;
+    ] ;
+
+    sh:property [
+        sh:path     thesis:advisor ;
+        sh:nodeKind sh:IRI ;
+    ] ;
+
+    sh:property [
+        sh:path     thesis:source-organization ;
+        sh:nodeKind sh:IRI ;
+        sh:maxCount 1 ;
+    ] ;
+.
+
+sh_sec:ThesisPersonRefShape
+    a sh:NodeShape ;
+    sh:targetClass thesis:PersonRef ;
+    sh:closed false ;
+
+    sh:property [
+        sh:path     thesis:name ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:severity sh:Violation ;
+        sh:message  "Person reference must have a name." ;
+    ] ;
+.

--- a/website/tool.json
+++ b/website/tool.json
@@ -9,7 +9,7 @@
         "name":                 { "@id": "tool:name",                 "@type": "xsd:string" },
         "description":          { "@id": "tool:description",          "@type": "xsd:string" },
         "url":                  { "@id": "tool:url",                  "@type": "@id" },
-        "same-as":              { "@id": "tool:same-as",              "@type": "@id" },
+        "external-url":         { "@id": "tool:external-url",         "@type": "@id" },
         "application-category": { "@id": "tool:application-category", "@type": "xsd:string" },
 
         "video": { "@id": "tool:video", "@type": "@id" },
@@ -19,7 +19,7 @@
 
         "keywords": {
             "@id":        "tool:keywords",
-            "@container": "@list"
+            "@container": "@set"
         }
     }
 }

--- a/website/tool.json
+++ b/website/tool.json
@@ -1,0 +1,25 @@
+{
+    "@context": {
+        "xsd": "http://www.w3.org/2001/XMLSchema#",
+        "tool": "https://secorolab.github.io/metamodels/website/tool#",
+
+        "Tool":        { "@id": "tool:Tool" },
+        "DemoVideo":   { "@id": "tool:DemoVideo" },
+
+        "name":                 { "@id": "tool:name",                 "@type": "xsd:string" },
+        "description":          { "@id": "tool:description",          "@type": "xsd:string" },
+        "url":                  { "@id": "tool:url",                  "@type": "@id" },
+        "same-as":              { "@id": "tool:same-as",              "@type": "@id" },
+        "application-category": { "@id": "tool:application-category", "@type": "xsd:string" },
+
+        "video": { "@id": "tool:video", "@type": "@id" },
+
+        "video-name": { "@id": "tool:video-name", "@type": "xsd:string" },
+        "video-url":  { "@id": "tool:video-url",  "@type": "@id" },
+
+        "keywords": {
+            "@id":        "tool:keywords",
+            "@container": "@list"
+        }
+    }
+}

--- a/website/tool.ttl
+++ b/website/tool.ttl
@@ -1,0 +1,83 @@
+@prefix sh:     <http://www.w3.org/ns/shacl#> .
+@prefix xsd:    <http://www.w3.org/2001/XMLSchema#> .
+@prefix sh_sec: <https://secorolab.github.io/metamodels/website/> .
+@prefix tool:   <https://secorolab.github.io/metamodels/website/tool#> .
+
+sh_sec:ToolShape
+    a sh:NodeShape ;
+    sh:targetClass tool:Tool ;
+    sh:closed false ;
+
+    sh:property [
+        sh:path     tool:name ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:minLength 2 ;
+        sh:severity sh:Violation ;
+        sh:message  "Tool must have a name." ;
+    ] ;
+
+    sh:property [
+        sh:path     tool:description ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:severity sh:Warning ;
+        sh:message  "Tool should have a description." ;
+    ] ;
+
+    sh:property [
+        sh:path     tool:url ;
+        sh:nodeKind sh:IRI ;
+        sh:maxCount 1 ;
+    ] ;
+
+    sh:property [
+        sh:path     tool:external-url ;
+        sh:nodeKind sh:IRI ;
+        sh:maxCount 1 ;
+    ] ;
+
+    sh:property [
+        sh:path     tool:application-category ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+    ] ;
+
+    sh:property [
+        sh:path     tool:video ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:maxCount 1 ;
+    ] ;
+
+    sh:property [
+        sh:path     tool:keywords ;
+        sh:datatype xsd:string ;
+        sh:severity sh:Warning ;
+        sh:message  "Tool should have at least one keyword." ;
+    ] ;
+.
+
+sh_sec:DemoVideoShape
+    a sh:NodeShape ;
+    sh:targetClass tool:DemoVideo ;
+    sh:closed false ;
+
+    sh:property [
+        sh:path     tool:video-name ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:severity sh:Violation ;
+        sh:message  "Demo video must have a name." ;
+    ] ;
+
+    sh:property [
+        sh:path     tool:video-url ;
+        sh:nodeKind sh:IRI ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:severity sh:Violation ;
+        sh:message  "Demo video must have a URL." ;
+    ] ;
+.


### PR DESCRIPTION
It is better to have the metamodels serving here, as it is a bit tricky for the [secorolab.github.io](https://github.com/secorolab/secorolab.github.io) configuration to serve and consume at the same time. 