### PR TITLE
refactor: extract shared website models and adopt scoped vocab contexts

### DIFF
--- a/website/group.json
+++ b/website/group.json
@@ -3,60 +3,21 @@
         "@base": "https://secorolab.github.io/",
         "xsd": "http://www.w3.org/2001/XMLSchema#",
         "group": "https://secorolab.github.io/metamodels/website/group#",
-        "ResearchGroup": {
-            "@id": "group:ResearchGroup"
-        },
-        "name": {
-            "@id": "group:name",
-            "@type": "xsd:string"
-        },
-        "alternate-name": {
-            "@id": "group:alternate-name",
-            "@type": "xsd:string"
-        },
-        "description": {
-            "@id": "group:description",
-            "@type": "xsd:string"
-        },
-        "email": {
-            "@id": "group:email",
-            "@type": "xsd:string"
-        },
-        "url": {
-            "@id": "group:url",
-            "@type": "@id"
-        },
-        "street-address": {
-            "@id": "group:street-address",
-            "@type": "xsd:string"
-        },
-        "address-locality": {
-            "@id": "group:address-locality",
-            "@type": "xsd:string"
-        },
-        "postal-code": {
-            "@id": "group:postal-code",
-            "@type": "xsd:string"
-        },
-        "address-country": {
-            "@id": "group:address-country",
-            "@type": "xsd:string"
-        },
-        "parent-org-name": {
-            "@id": "group:parent-org-name",
-            "@type": "xsd:string"
-        },
-        "parent-org-url": {
-            "@id": "group:parent-org-url",
-            "@type": "@id"
-        },
-        "department-name": {
-            "@id": "group:department-name",
-            "@type": "xsd:string"
-        },
-        "mission": {
-            "@id": "group:mission",
-            "@type": "xsd:string"
-        }
+
+        "ResearchGroup": { "@id": "group:ResearchGroup" },
+
+        "name":             { "@id": "group:name",             "@type": "xsd:string" },
+        "alternate-name":   { "@id": "group:alternate-name",   "@type": "xsd:string" },
+        "description":      { "@id": "group:description",      "@type": "xsd:string" },
+        "email":            { "@id": "group:email",            "@type": "xsd:string" },
+        "url":              { "@id": "group:url",              "@type": "@id" },
+        "street-address":   { "@id": "group:street-address",   "@type": "xsd:string" },
+        "address-locality": { "@id": "group:address-locality", "@type": "xsd:string" },
+        "postal-code":      { "@id": "group:postal-code",      "@type": "xsd:string" },
+        "address-country":  { "@id": "group:address-country",  "@type": "xsd:string" },
+        "parent-org-name":  { "@id": "group:parent-org-name",  "@type": "xsd:string" },
+        "parent-org-url":   { "@id": "group:parent-org-url",   "@type": "@id" },
+        "department-name":  { "@id": "group:department-name",  "@type": "xsd:string" },
+        "mission":          { "@id": "group:mission",          "@type": "xsd:string" }
     }
 }

--- a/website/group.json
+++ b/website/group.json
@@ -1,22 +1,62 @@
 {
     "@context": {
+        "@base": "https://secorolab.github.io/",
         "xsd": "http://www.w3.org/2001/XMLSchema#",
         "group": "https://secorolab.github.io/metamodels/website/group#",
-
-        "ResearchGroup": { "@id": "group:ResearchGroup" },
-
-        "name":             { "@id": "group:name",             "@type": "xsd:string" },
-        "alternate-name":   { "@id": "group:alternate-name",   "@type": "xsd:string" },
-        "description":      { "@id": "group:description",      "@type": "xsd:string" },
-        "email":            { "@id": "group:email",            "@type": "xsd:string" },
-        "url":              { "@id": "group:url",              "@type": "@id" },
-        "street-address":   { "@id": "group:street-address",   "@type": "xsd:string" },
-        "address-locality": { "@id": "group:address-locality", "@type": "xsd:string" },
-        "postal-code":      { "@id": "group:postal-code",      "@type": "xsd:string" },
-        "address-country":  { "@id": "group:address-country",  "@type": "xsd:string" },
-        "parent-org-name":  { "@id": "group:parent-org-name",  "@type": "xsd:string" },
-        "parent-org-url":   { "@id": "group:parent-org-url",   "@type": "@id" },
-        "department-name":  { "@id": "group:department-name",  "@type": "xsd:string" },
-        "mission":          { "@id": "group:mission",          "@type": "xsd:string" }
+        "ResearchGroup": {
+            "@id": "group:ResearchGroup"
+        },
+        "name": {
+            "@id": "group:name",
+            "@type": "xsd:string"
+        },
+        "alternate-name": {
+            "@id": "group:alternate-name",
+            "@type": "xsd:string"
+        },
+        "description": {
+            "@id": "group:description",
+            "@type": "xsd:string"
+        },
+        "email": {
+            "@id": "group:email",
+            "@type": "xsd:string"
+        },
+        "url": {
+            "@id": "group:url",
+            "@type": "@id"
+        },
+        "street-address": {
+            "@id": "group:street-address",
+            "@type": "xsd:string"
+        },
+        "address-locality": {
+            "@id": "group:address-locality",
+            "@type": "xsd:string"
+        },
+        "postal-code": {
+            "@id": "group:postal-code",
+            "@type": "xsd:string"
+        },
+        "address-country": {
+            "@id": "group:address-country",
+            "@type": "xsd:string"
+        },
+        "parent-org-name": {
+            "@id": "group:parent-org-name",
+            "@type": "xsd:string"
+        },
+        "parent-org-url": {
+            "@id": "group:parent-org-url",
+            "@type": "@id"
+        },
+        "department-name": {
+            "@id": "group:department-name",
+            "@type": "xsd:string"
+        },
+        "mission": {
+            "@id": "group:mission",
+            "@type": "xsd:string"
+        }
     }
 }

--- a/website/image.json
+++ b/website/image.json
@@ -1,0 +1,15 @@
+{
+    "@context": {
+        "@base": "https://secorolab.github.io/",
+        "xsd": "http://www.w3.org/2001/XMLSchema#",
+        "img": "https://secorolab.github.io/metamodels/website/image#",
+
+        "Image": { "@id": "img:Image" },
+
+        "image":     { "@id": "img:image",     "@type": "@id" },
+        "logo":      { "@id": "img:logo",      "@type": "@id" },
+        "url":       { "@id": "img:url",       "@type": "@id" },
+        "caption":   { "@id": "img:caption",   "@type": "xsd:string" },
+        "copyright": { "@id": "img:copyright", "@type": "xsd:string" }
+    }
+}

--- a/website/image.ttl
+++ b/website/image.ttl
@@ -1,0 +1,31 @@
+@prefix sh:     <http://www.w3.org/ns/shacl#> .
+@prefix xsd:    <http://www.w3.org/2001/XMLSchema#> .
+@prefix sh_sec: <https://secorolab.github.io/metamodels/website/> .
+@prefix image:  <https://secorolab.github.io/metamodels/website/image#> .
+
+sh_sec:ImageShape
+    a sh:NodeShape ;
+    sh:targetClass image:Image ;
+    sh:closed false ;
+
+    sh:property [
+        sh:path     image:url ;
+        sh:nodeKind sh:IRI ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:severity sh:Violation ;
+        sh:message  "Image must have exactly one URL." ;
+    ] ;
+
+    sh:property [
+        sh:path     image:caption ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+    ] ;
+
+    sh:property [
+        sh:path     image:copyright ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+    ] ;
+.

--- a/website/keyword.json
+++ b/website/keyword.json
@@ -1,0 +1,22 @@
+{
+    "@context": {
+        "@base": "https://secorolab.github.io/",
+        "xsd": "http://www.w3.org/2001/XMLSchema#",
+        "kw": "https://secorolab.github.io/metamodels/website/keyword#",
+        "Keyword": {
+            "@id": "kw:Keyword",
+            "@context": {
+                "name": {
+                    "@id": "kw:name",
+                    "@type": "xsd:string"
+                }
+            }
+        },
+        "keywords": {
+            "@id": "kw:keywords",
+            "@type": "@vocab",
+            "@container": "@set"
+        },
+        "@vocab": "https://secorolab.github.io/keywords/"
+    }
+}

--- a/website/keyword.ttl
+++ b/website/keyword.ttl
@@ -1,0 +1,16 @@
+@prefix sh:     <http://www.w3.org/ns/shacl#> .
+@prefix xsd:    <http://www.w3.org/2001/XMLSchema#> .
+@prefix sh_sec: <https://secorolab.github.io/metamodels/website/> .
+@prefix kw:     <https://secorolab.github.io/metamodels/website/keyword#> .
+
+sh_sec:KeywordShape
+    a sh:NodeShape ;
+    sh:targetClass kw:Keyword ;
+    sh:closed false ;
+
+    sh:property [
+        sh:path     kw:name ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+    ] ;
+.

--- a/website/news.json
+++ b/website/news.json
@@ -3,28 +3,17 @@
         "@base": "https://secorolab.github.io/",
         "xsd": "http://www.w3.org/2001/XMLSchema#",
         "news": "https://secorolab.github.io/metamodels/website/news#",
-        "NewsArticle": {
-            "@id": "news:NewsArticle"
-        },
-        "name": {
-            "@id": "news:name",
-            "@type": "xsd:string"
-        },
-        "description": {
-            "@id": "news:description",
-            "@type": "xsd:string"
-        },
-        "date-published": {
-            "@id": "news:date-published",
-            "@type": "xsd:date"
-        },
-        "url": {
-            "@id": "news:url",
-            "@type": "@id"
-        },
+
+        "NewsArticle": { "@id": "news:NewsArticle" },
+
+        "name":           { "@id": "news:name",           "@type": "xsd:string" },
+        "description":    { "@id": "news:description",    "@type": "xsd:string" },
+        "date-published": { "@id": "news:date-published", "@type": "xsd:date" },
+        "url":            { "@id": "news:url",            "@type": "@id" },
+
         "about": {
-            "@id": "news:about",
-            "@type": "@id",
+            "@id":        "news:about",
+            "@type":      "@id",
             "@container": "@set"
         }
     }

--- a/website/news.json
+++ b/website/news.json
@@ -1,23 +1,30 @@
 {
     "@context": {
+        "@base": "https://secorolab.github.io/",
         "xsd": "http://www.w3.org/2001/XMLSchema#",
         "news": "https://secorolab.github.io/metamodels/website/news#",
-
-        "NewsArticle": { "@id": "news:NewsArticle" },
-
-        "name":           { "@id": "news:name",           "@type": "xsd:string" },
-        "description":    { "@id": "news:description",    "@type": "xsd:string" },
-        "date-published": { "@id": "news:date-published", "@type": "xsd:date" },
-        "url":            { "@id": "news:url",            "@type": "@id" },
-
-        "about": {
-            "@id":        "news:about",
-            "@type":      "@id",
-            "@container": "@set"
+        "NewsArticle": {
+            "@id": "news:NewsArticle"
         },
-
-        "keywords": {
-            "@id":        "news:keywords",
+        "name": {
+            "@id": "news:name",
+            "@type": "xsd:string"
+        },
+        "description": {
+            "@id": "news:description",
+            "@type": "xsd:string"
+        },
+        "date-published": {
+            "@id": "news:date-published",
+            "@type": "xsd:date"
+        },
+        "url": {
+            "@id": "news:url",
+            "@type": "@id"
+        },
+        "about": {
+            "@id": "news:about",
+            "@type": "@id",
             "@container": "@set"
         }
     }

--- a/website/news.ttl
+++ b/website/news.ttl
@@ -2,6 +2,7 @@
 @prefix xsd:    <http://www.w3.org/2001/XMLSchema#> .
 @prefix sh_sec: <https://secorolab.github.io/metamodels/website/> .
 @prefix news:   <https://secorolab.github.io/metamodels/website/news#> .
+@prefix kw:     <https://secorolab.github.io/metamodels/website/keyword#> .
 
 sh_sec:NewsShape
     a sh:NodeShape ;
@@ -44,9 +45,11 @@ sh_sec:NewsShape
         sh:path     news:about ;
         sh:nodeKind sh:IRI ;
     ] ;
-
     sh:property [
-        sh:path     news:keywords ;
-        sh:datatype xsd:string ;
+        sh:path     kw:keywords ;
+        sh:nodeKind sh:IRI ;
+        sh:severity sh:Warning ;
+        sh:message  "News keywords should reference keyword IRIs." ;
     ] ;
+
 .

--- a/website/opening.json
+++ b/website/opening.json
@@ -3,66 +3,28 @@
         "@base": "https://secorolab.github.io/",
         "xsd": "http://www.w3.org/2001/XMLSchema#",
         "opening": "https://secorolab.github.io/metamodels/website/opening#",
-        "JobPosting": {
-            "@id": "opening:JobPosting"
-        },
-        "Organization": {
-            "@id": "opening:Organization"
-        },
-        "title": {
-            "@id": "opening:title",
-            "@type": "xsd:string"
-        },
-        "description": {
-            "@id": "opening:description",
-            "@type": "xsd:string"
-        },
-        "employment-type": {
-            "@id": "opening:employment-type",
-            "@type": "xsd:string"
-        },
-        "qualifications": {
-            "@id": "opening:qualifications",
-            "@type": "xsd:string"
-        },
-        "responsibilities": {
-            "@id": "opening:responsibilities",
-            "@type": "xsd:string"
-        },
-        "skills": {
-            "@id": "opening:skills",
-            "@type": "xsd:string"
-        },
-        "incentive-compensation": {
-            "@id": "opening:incentive-compensation",
-            "@type": "xsd:string"
-        },
-        "date-posted": {
-            "@id": "opening:date-posted",
-            "@type": "xsd:date"
-        },
-        "valid-through": {
-            "@id": "opening:valid-through",
-            "@type": "xsd:date"
-        },
-        "hiring-organization": {
-            "@id": "opening:hiring-organization",
-            "@type": "@id"
-        },
-        "job-location": {
-            "@id": "opening:job-location",
-            "@type": "@id"
-        },
-        "org-name": {
-            "@id": "opening:org-name",
-            "@type": "xsd:string"
-        },
-        "org-url": {
-            "@id": "opening:org-url",
-            "@type": "@id"
-        },
+
+        "JobPosting":    { "@id": "opening:JobPosting" },
+        "Organization":  { "@id": "opening:Organization" },
+
+        "title":               { "@id": "opening:title",               "@type": "xsd:string" },
+        "description":         { "@id": "opening:description",         "@type": "xsd:string" },
+        "employment-type":     { "@id": "opening:employment-type",     "@type": "xsd:string" },
+        "qualifications":      { "@id": "opening:qualifications",      "@type": "xsd:string" },
+        "responsibilities":    { "@id": "opening:responsibilities",    "@type": "xsd:string" },
+        "skills":              { "@id": "opening:skills",              "@type": "xsd:string" },
+        "incentive-compensation": { "@id": "opening:incentive-compensation", "@type": "xsd:string" },
+        "date-posted":         { "@id": "opening:date-posted",         "@type": "xsd:date" },
+        "valid-through":       { "@id": "opening:valid-through",       "@type": "xsd:date" },
+
+        "hiring-organization": { "@id": "opening:hiring-organization", "@type": "@id" },
+        "job-location":        { "@id": "opening:job-location",        "@type": "@id" },
+
+        "org-name": { "@id": "opening:org-name", "@type": "xsd:string" },
+        "org-url":  { "@id": "opening:org-url",  "@type": "@id" },
+
         "applicant-location-requirements": {
-            "@id": "opening:applicant-location-requirements",
+            "@id":        "opening:applicant-location-requirements",
             "@container": "@set"
         }
     }

--- a/website/opening.json
+++ b/website/opening.json
@@ -1,29 +1,68 @@
 {
     "@context": {
+        "@base": "https://secorolab.github.io/",
         "xsd": "http://www.w3.org/2001/XMLSchema#",
         "opening": "https://secorolab.github.io/metamodels/website/opening#",
-
-        "JobPosting":    { "@id": "opening:JobPosting" },
-        "Organization":  { "@id": "opening:Organization" },
-
-        "title":               { "@id": "opening:title",               "@type": "xsd:string" },
-        "description":         { "@id": "opening:description",         "@type": "xsd:string" },
-        "employment-type":     { "@id": "opening:employment-type",     "@type": "xsd:string" },
-        "qualifications":      { "@id": "opening:qualifications",      "@type": "xsd:string" },
-        "responsibilities":    { "@id": "opening:responsibilities",    "@type": "xsd:string" },
-        "skills":              { "@id": "opening:skills",              "@type": "xsd:string" },
-        "incentive-compensation": { "@id": "opening:incentive-compensation", "@type": "xsd:string" },
-        "date-posted":         { "@id": "opening:date-posted",         "@type": "xsd:date" },
-        "valid-through":       { "@id": "opening:valid-through",       "@type": "xsd:date" },
-
-        "hiring-organization": { "@id": "opening:hiring-organization", "@type": "@id" },
-        "job-location":        { "@id": "opening:job-location",        "@type": "@id" },
-
-        "org-name": { "@id": "opening:org-name", "@type": "xsd:string" },
-        "org-url":  { "@id": "opening:org-url",  "@type": "@id" },
-
+        "JobPosting": {
+            "@id": "opening:JobPosting"
+        },
+        "Organization": {
+            "@id": "opening:Organization"
+        },
+        "title": {
+            "@id": "opening:title",
+            "@type": "xsd:string"
+        },
+        "description": {
+            "@id": "opening:description",
+            "@type": "xsd:string"
+        },
+        "employment-type": {
+            "@id": "opening:employment-type",
+            "@type": "xsd:string"
+        },
+        "qualifications": {
+            "@id": "opening:qualifications",
+            "@type": "xsd:string"
+        },
+        "responsibilities": {
+            "@id": "opening:responsibilities",
+            "@type": "xsd:string"
+        },
+        "skills": {
+            "@id": "opening:skills",
+            "@type": "xsd:string"
+        },
+        "incentive-compensation": {
+            "@id": "opening:incentive-compensation",
+            "@type": "xsd:string"
+        },
+        "date-posted": {
+            "@id": "opening:date-posted",
+            "@type": "xsd:date"
+        },
+        "valid-through": {
+            "@id": "opening:valid-through",
+            "@type": "xsd:date"
+        },
+        "hiring-organization": {
+            "@id": "opening:hiring-organization",
+            "@type": "@id"
+        },
+        "job-location": {
+            "@id": "opening:job-location",
+            "@type": "@id"
+        },
+        "org-name": {
+            "@id": "opening:org-name",
+            "@type": "xsd:string"
+        },
+        "org-url": {
+            "@id": "opening:org-url",
+            "@type": "@id"
+        },
         "applicant-location-requirements": {
-            "@id":        "opening:applicant-location-requirements",
+            "@id": "opening:applicant-location-requirements",
             "@container": "@set"
         }
     }

--- a/website/partner.json
+++ b/website/partner.json
@@ -8,7 +8,6 @@
 
         "name":        { "@id": "partner:name",        "@type": "xsd:string" },
         "description": { "@id": "partner:description", "@type": "xsd:string" },
-        "url":         { "@id": "partner:url",         "@type": "@id" },
-        "logo":        { "@id": "partner:logo",        "@type": "@id" }
+        "url":         { "@id": "partner:url",         "@type": "@id" }
     }
 }

--- a/website/partner.ttl
+++ b/website/partner.ttl
@@ -33,11 +33,4 @@ sh_sec:PartnerShape
         sh:message  "Partner should have a URL." ;
     ] ;
 
-    sh:property [
-        sh:path     partner:logo ;
-        sh:nodeKind sh:IRI ;
-        sh:maxCount 1 ;
-        sh:severity sh:Warning ;
-        sh:message  "Partner should have a logo." ;
-    ] ;
 .

--- a/website/person-ref.json
+++ b/website/person-ref.json
@@ -1,0 +1,16 @@
+{
+    "@context": {
+        "@base": "https://secorolab.github.io/",
+        "xsd": "http://www.w3.org/2001/XMLSchema#",
+        "person-ref": "https://secorolab.github.io/metamodels/website/person-ref#",
+        "PersonRef": {
+            "@id": "person-ref:PersonRef",
+            "@context": {
+                "name": {
+                    "@id": "person-ref:name",
+                    "@type": "xsd:string"
+                }
+            }
+        }
+    }
+}

--- a/website/person-ref.ttl
+++ b/website/person-ref.ttl
@@ -1,0 +1,19 @@
+@prefix sh:         <http://www.w3.org/ns/shacl#> .
+@prefix xsd:        <http://www.w3.org/2001/XMLSchema#> .
+@prefix sh_sec:     <https://secorolab.github.io/metamodels/website/> .
+@prefix person-ref: <https://secorolab.github.io/metamodels/website/person-ref#> .
+
+sh_sec:PersonRefShape
+    a sh:NodeShape ;
+    sh:targetClass person-ref:PersonRef ;
+    sh:closed false ;
+
+    sh:property [
+        sh:path     person-ref:name ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:severity sh:Violation ;
+        sh:message  "Person reference must have a name." ;
+    ] ;
+.

--- a/website/person.json
+++ b/website/person.json
@@ -3,44 +3,105 @@
         "@base": "https://secorolab.github.io/",
         "xsd": "http://www.w3.org/2001/XMLSchema#",
         "person": "https://secorolab.github.io/metamodels/website/person#",
-
-        "Person":         { "@id": "person:Person" },
-        "Internal":       { "@id": "person:Internal" },
-        "External":       { "@id": "person:External" },
-        "Professor":      { "@id": "person:Professor" },
-        "Administration": { "@id": "person:Administration" },
-        "PhDStudent":     { "@id": "person:PhDStudent" },
-        "HiWiStudent":    { "@id": "person:HiWiStudent" },
-        "Postdoc":        { "@id": "person:Postdoc" },
-        "Researcher":     { "@id": "person:Researcher" },
-
-        "first-name":   { "@id": "person:first-name",  "@type": "xsd:string" },
-        "last-name":    { "@id": "person:last-name",   "@type": "xsd:string" },
-        "middle-name":  { "@id": "person:middle-name", "@type": "xsd:string" },
-        "job-title":    { "@id": "person:job-title",   "@type": "xsd:string" },
-        "email":        { "@id": "person:email",       "@type": "xsd:string" },
-        "telephone":    { "@id": "person:telephone",   "@type": "xsd:string" },
-        "office-address": { "@id": "person:office-address", "@type": "xsd:string" },
-        "url":          { "@id": "person:url",         "@type": "@id" },
-        "orcid":        { "@id": "person:orcid",       "@type": "@id" },
-        "g-scholar":    { "@id": "person:g-scholar",   "@type": "@id" },
-        "linkedin":     { "@id": "person:linkedin",    "@type": "@id" },
-        "github":       { "@id": "person:github",      "@type": "@id" },
-        "twitter":      { "@id": "person:twitter",     "@type": "@id" },
-        "image":        { "@id": "person:image",       "@type": "@id" },
-        "start-date":   { "@id": "person:start-date",  "@type": "xsd:date" },
-        "end-date":     { "@id": "person:end-date",    "@type": "xsd:date" },
-
+        "Person": {
+            "@id": "person:Person"
+        },
+        "Internal": {
+            "@id": "person:Internal"
+        },
+        "External": {
+            "@id": "person:External"
+        },
+        "Professor": {
+            "@id": "person:Professor"
+        },
+        "Administration": {
+            "@id": "person:Administration"
+        },
+        "PhDStudent": {
+            "@id": "person:PhDStudent"
+        },
+        "HiWiStudent": {
+            "@id": "person:HiWiStudent"
+        },
+        "Postdoc": {
+            "@id": "person:Postdoc"
+        },
+        "Researcher": {
+            "@id": "person:Researcher"
+        },
+        "first-name": {
+            "@id": "person:first-name",
+            "@type": "xsd:string"
+        },
+        "last-name": {
+            "@id": "person:last-name",
+            "@type": "xsd:string"
+        },
+        "middle-name": {
+            "@id": "person:middle-name",
+            "@type": "xsd:string"
+        },
+        "job-title": {
+            "@id": "person:job-title",
+            "@type": "xsd:string"
+        },
+        "email": {
+            "@id": "person:email",
+            "@type": "xsd:string"
+        },
+        "telephone": {
+            "@id": "person:telephone",
+            "@type": "xsd:string"
+        },
+        "office-address": {
+            "@id": "person:office-address",
+            "@type": "xsd:string"
+        },
+        "url": {
+            "@id": "person:url",
+            "@type": "@id"
+        },
+        "orcid": {
+            "@id": "person:orcid",
+            "@type": "@id"
+        },
+        "g-scholar": {
+            "@id": "person:g-scholar",
+            "@type": "@id"
+        },
+        "linkedin": {
+            "@id": "person:linkedin",
+            "@type": "@id"
+        },
+        "github": {
+            "@id": "person:github",
+            "@type": "@id"
+        },
+        "twitter": {
+            "@id": "person:twitter",
+            "@type": "@id"
+        },
+        "start-date": {
+            "@id": "person:start-date",
+            "@type": "xsd:date"
+        },
+        "end-date": {
+            "@id": "person:end-date",
+            "@type": "xsd:date"
+        },
         "name-alias": {
-            "@id":        "person:name-alias",
-            "@type":      "xsd:string",
+            "@id": "person:name-alias",
+            "@type": "xsd:string",
             "@container": "@set"
         },
-
         "knows-about": {
-            "@id":        "person:knows-about",
-            "@type":      "@id",
-            "@container": "@set"
+            "@id": "person:knows-about",
+            "@type": "@vocab",
+            "@container": "@set",
+            "@context": {
+                "@vocab": "https://secorolab.github.io/research/"
+            }
         }
     }
 }

--- a/website/person.json
+++ b/website/person.json
@@ -3,105 +3,44 @@
         "@base": "https://secorolab.github.io/",
         "xsd": "http://www.w3.org/2001/XMLSchema#",
         "person": "https://secorolab.github.io/metamodels/website/person#",
-        "Person": {
-            "@id": "person:Person"
-        },
-        "Internal": {
-            "@id": "person:Internal"
-        },
-        "External": {
-            "@id": "person:External"
-        },
-        "Professor": {
-            "@id": "person:Professor"
-        },
-        "Administration": {
-            "@id": "person:Administration"
-        },
-        "PhDStudent": {
-            "@id": "person:PhDStudent"
-        },
-        "HiWiStudent": {
-            "@id": "person:HiWiStudent"
-        },
-        "Postdoc": {
-            "@id": "person:Postdoc"
-        },
-        "Researcher": {
-            "@id": "person:Researcher"
-        },
-        "first-name": {
-            "@id": "person:first-name",
-            "@type": "xsd:string"
-        },
-        "last-name": {
-            "@id": "person:last-name",
-            "@type": "xsd:string"
-        },
-        "middle-name": {
-            "@id": "person:middle-name",
-            "@type": "xsd:string"
-        },
-        "job-title": {
-            "@id": "person:job-title",
-            "@type": "xsd:string"
-        },
-        "email": {
-            "@id": "person:email",
-            "@type": "xsd:string"
-        },
-        "telephone": {
-            "@id": "person:telephone",
-            "@type": "xsd:string"
-        },
-        "office-address": {
-            "@id": "person:office-address",
-            "@type": "xsd:string"
-        },
-        "url": {
-            "@id": "person:url",
-            "@type": "@id"
-        },
-        "orcid": {
-            "@id": "person:orcid",
-            "@type": "@id"
-        },
-        "g-scholar": {
-            "@id": "person:g-scholar",
-            "@type": "@id"
-        },
-        "linkedin": {
-            "@id": "person:linkedin",
-            "@type": "@id"
-        },
-        "github": {
-            "@id": "person:github",
-            "@type": "@id"
-        },
-        "twitter": {
-            "@id": "person:twitter",
-            "@type": "@id"
-        },
-        "start-date": {
-            "@id": "person:start-date",
-            "@type": "xsd:date"
-        },
-        "end-date": {
-            "@id": "person:end-date",
-            "@type": "xsd:date"
-        },
+
+        "Person":         { "@id": "person:Person" },
+        "Internal":       { "@id": "person:Internal" },
+        "External":       { "@id": "person:External" },
+        "Professor":      { "@id": "person:Professor" },
+        "Administration": { "@id": "person:Administration" },
+        "PhDStudent":     { "@id": "person:PhDStudent" },
+        "HiWiStudent":    { "@id": "person:HiWiStudent" },
+        "Postdoc":        { "@id": "person:Postdoc" },
+        "Researcher":     { "@id": "person:Researcher" },
+
+        "first-name":   { "@id": "person:first-name",  "@type": "xsd:string" },
+        "last-name":    { "@id": "person:last-name",   "@type": "xsd:string" },
+        "middle-name":  { "@id": "person:middle-name", "@type": "xsd:string" },
+        "job-title":    { "@id": "person:job-title",   "@type": "xsd:string" },
+        "email":        { "@id": "person:email",       "@type": "xsd:string" },
+        "telephone":    { "@id": "person:telephone",   "@type": "xsd:string" },
+        "office-address": { "@id": "person:office-address", "@type": "xsd:string" },
+        "url":          { "@id": "person:url",         "@type": "@id" },
+        "orcid":        { "@id": "person:orcid",       "@type": "@id" },
+        "g-scholar":    { "@id": "person:g-scholar",   "@type": "@id" },
+        "linkedin":     { "@id": "person:linkedin",    "@type": "@id" },
+        "github":       { "@id": "person:github",      "@type": "@id" },
+        "twitter":      { "@id": "person:twitter",     "@type": "@id" },
+        "image":        { "@id": "person:image",       "@type": "@id" },
+        "start-date":   { "@id": "person:start-date",  "@type": "xsd:date" },
+        "end-date":     { "@id": "person:end-date",    "@type": "xsd:date" },
+
         "name-alias": {
-            "@id": "person:name-alias",
-            "@type": "xsd:string",
+            "@id":        "person:name-alias",
+            "@type":      "xsd:string",
             "@container": "@set"
         },
+
         "knows-about": {
-            "@id": "person:knows-about",
-            "@type": "@vocab",
-            "@container": "@set",
-            "@context": {
-                "@vocab": "https://secorolab.github.io/research/"
-            }
+            "@id":        "person:knows-about",
+            "@type":      "@id",
+            "@container": "@set"
         }
     }
 }

--- a/website/person.ttl
+++ b/website/person.ttl
@@ -97,11 +97,6 @@ sh_sec:PersonShape
         sh:maxCount 1 ;
     ] ;
 
-    sh:property [
-        sh:path     person:image ;
-        sh:nodeKind sh:IRI ;
-        sh:maxCount 1 ;
-    ] ;
 
     sh:property [
         sh:path     person:start-date ;

--- a/website/project.json
+++ b/website/project.json
@@ -3,26 +3,51 @@
         "@base": "https://secorolab.github.io/",
         "xsd": "http://www.w3.org/2001/XMLSchema#",
         "project": "https://secorolab.github.io/metamodels/website/project#",
-
-        "Project":      { "@id": "project:Project" },
-        "FunderOrg":    { "@id": "project:FunderOrg" },
-
-        "name":        { "@id": "project:name",        "@type": "xsd:string" },
-        "description": { "@id": "project:description", "@type": "xsd:string" },
-        "start-date":  { "@id": "project:start-date",  "@type": "xsd:date" },
-        "end-date":    { "@id": "project:end-date",    "@type": "xsd:date" },
-        "url":         { "@id": "project:url",         "@type": "@id" },
-        "logo":        { "@id": "project:logo",        "@type": "@id" },
-
-        "funder": { "@id": "project:funder", "@type": "@id" },
-
-        "funder-name": { "@id": "project:funder-name", "@type": "xsd:string" },
-        "funder-url":  { "@id": "project:funder-url",  "@type": "@id" },
-
+        "Project": {
+            "@id": "project:Project"
+        },
+        "FunderOrg": {
+            "@id": "project:FunderOrg"
+        },
+        "name": {
+            "@id": "project:name",
+            "@type": "xsd:string"
+        },
+        "description": {
+            "@id": "project:description",
+            "@type": "xsd:string"
+        },
+        "start-date": {
+            "@id": "project:start-date",
+            "@type": "xsd:date"
+        },
+        "end-date": {
+            "@id": "project:end-date",
+            "@type": "xsd:date"
+        },
+        "url": {
+            "@id": "project:url",
+            "@type": "@id"
+        },
+        "funder": {
+            "@id": "project:funder",
+            "@type": "@id"
+        },
+        "funder-name": {
+            "@id": "project:funder-name",
+            "@type": "xsd:string"
+        },
+        "funder-url": {
+            "@id": "project:funder-url",
+            "@type": "@id"
+        },
         "member": {
-            "@id":        "project:member",
-            "@type":      "@id",
-            "@container": "@set"
+            "@id": "project:member",
+            "@type": "@vocab",
+            "@container": "@set",
+            "@context": {
+                "@vocab": "https://secorolab.github.io/people/"
+            }
         }
     }
 }

--- a/website/project.json
+++ b/website/project.json
@@ -3,47 +3,24 @@
         "@base": "https://secorolab.github.io/",
         "xsd": "http://www.w3.org/2001/XMLSchema#",
         "project": "https://secorolab.github.io/metamodels/website/project#",
-        "Project": {
-            "@id": "project:Project"
-        },
-        "FunderOrg": {
-            "@id": "project:FunderOrg"
-        },
-        "name": {
-            "@id": "project:name",
-            "@type": "xsd:string"
-        },
-        "description": {
-            "@id": "project:description",
-            "@type": "xsd:string"
-        },
-        "start-date": {
-            "@id": "project:start-date",
-            "@type": "xsd:date"
-        },
-        "end-date": {
-            "@id": "project:end-date",
-            "@type": "xsd:date"
-        },
-        "url": {
-            "@id": "project:url",
-            "@type": "@id"
-        },
-        "funder": {
-            "@id": "project:funder",
-            "@type": "@id"
-        },
-        "funder-name": {
-            "@id": "project:funder-name",
-            "@type": "xsd:string"
-        },
-        "funder-url": {
-            "@id": "project:funder-url",
-            "@type": "@id"
-        },
+
+        "Project":      { "@id": "project:Project" },
+        "FunderOrg":    { "@id": "project:FunderOrg" },
+
+        "name":        { "@id": "project:name",        "@type": "xsd:string" },
+        "description": { "@id": "project:description", "@type": "xsd:string" },
+        "start-date":  { "@id": "project:start-date",  "@type": "xsd:date" },
+        "end-date":    { "@id": "project:end-date",    "@type": "xsd:date" },
+        "url":         { "@id": "project:url",         "@type": "@id" },
+
+        "funder": { "@id": "project:funder", "@type": "@id" },
+
+        "funder-name": { "@id": "project:funder-name", "@type": "xsd:string" },
+        "funder-url":  { "@id": "project:funder-url",  "@type": "@id" },
+
         "member": {
-            "@id": "project:member",
-            "@type": "@vocab",
+            "@id":        "project:member",
+            "@type":      "@vocab",
             "@container": "@set",
             "@context": {
                 "@vocab": "https://secorolab.github.io/people/"

--- a/website/project.ttl
+++ b/website/project.ttl
@@ -32,13 +32,6 @@ sh_sec:ProjectShape
         sh:maxCount 1 ;
     ] ;
 
-    sh:property [
-        sh:path     project:logo ;
-        sh:nodeKind sh:IRI ;
-        sh:maxCount 1 ;
-        sh:severity sh:Warning ;
-        sh:message  "Project should have a logo." ;
-    ] ;
 
     sh:property [
         sh:path     project:start-date ;

--- a/website/publication.json
+++ b/website/publication.json
@@ -3,86 +3,49 @@
         "@base": "https://secorolab.github.io/",
         "xsd": "http://www.w3.org/2001/XMLSchema#",
         "publication": "https://secorolab.github.io/metamodels/website/publication#",
-        "Publication": {
-            "@id": "publication:Publication"
-        },
+
+        "Publication": { "@id": "publication:Publication" },
         "PublicationVenue": {
             "@id": "publication:PublicationVenue",
             "@context": {
-                "name": {
-                    "@id": "publication:name",
-                    "@type": "xsd:string"
-                },
-                "url": {
-                    "@id": "publication:url",
-                    "@type": "@id"
-                }
+                "name": { "@id": "publication:name", "@type": "xsd:string" },
+                "url":  { "@id": "publication:url",  "@type": "@id" }
             }
         },
         "Preprint": {
             "@id": "publication:Preprint",
             "@context": {
-                "where": {
-                    "@id": "publication:preprint-where",
-                    "@type": "xsd:string"
-                },
-                "url": {
-                    "@id": "publication:url",
-                    "@type": "@id"
-                }
+                "where": { "@id": "publication:preprint-where", "@type": "xsd:string" },
+                "url":   { "@id": "publication:url",            "@type": "@id" }
             }
         },
-        "name": {
-            "@id": "publication:name",
-            "@type": "xsd:string"
-        },
-        "bib-id": {
-            "@id": "publication:bib-id",
-            "@type": "xsd:string"
-        },
-        "date-published": {
-            "@id": "publication:date-published",
-            "@type": "xsd:date"
-        },
-        "url": {
-            "@id": "publication:url",
-            "@type": "@id"
-        },
-        "doi": {
-            "@id": "publication:doi",
-            "@type": "@id"
-        },
-        "website": {
-            "@id": "publication:website",
-            "@type": "@id"
-        },
+        "PersonRef":   { "@id": "publication:PersonRef" },
+
+        "name":           { "@id": "publication:name",           "@type": "xsd:string" },
+        "bib-id":         { "@id": "publication:bib-id",         "@type": "xsd:string" },
+        "date-published": { "@id": "publication:date-published", "@type": "xsd:date" },
+        "url":            { "@id": "publication:url",            "@type": "@id" },
+        "doi":            { "@id": "publication:doi",            "@type": "@id" },
+        "website":        { "@id": "publication:website",        "@type": "@id" },
+
         "author": {
-            "@id": "publication:author",
-            "@type": "@id",
-            "@container": "@set",
-            "@context": {
-                "@vocab": "https://secorolab.github.io/people/"
-            }
+            "@id":        "publication:author",
+            "@type":      "@id",
+            "@container": "@set"
         },
-        "published-in": {
-            "@id": "publication:published-in",
-            "@type": "@id"
-        },
-        "preprint": {
-            "@id": "publication:preprint",
-            "@type": "@id"
-        },
+
+        "published-in": { "@id": "publication:published-in", "@type": "@id" },
+        "preprint":     { "@id": "publication:preprint",     "@type": "@id" },
+
         "related-tools": {
-            "@id": "publication:related-tools",
-            "@type": "@vocab",
-            "@container": "@set",
-            "@context": {
-                "@vocab": "https://secorolab.github.io/tools/"
-            }
+            "@id":        "publication:related-tools",
+            "@type":      "@id",
+            "@container": "@set"
         },
+
         "about": {
-            "@id": "publication:about",
-            "@type": "@id",
+            "@id":        "publication:about",
+            "@type":      "@id",
             "@container": "@set"
         }
     }

--- a/website/publication.json
+++ b/website/publication.json
@@ -1,50 +1,88 @@
 {
     "@context": {
+        "@base": "https://secorolab.github.io/",
         "xsd": "http://www.w3.org/2001/XMLSchema#",
         "publication": "https://secorolab.github.io/metamodels/website/publication#",
-
-        "Publication": { "@id": "publication:Publication" },
+        "Publication": {
+            "@id": "publication:Publication"
+        },
         "PublicationVenue": {
             "@id": "publication:PublicationVenue",
             "@context": {
-                "name": { "@id": "publication:name", "@type": "xsd:string" },
-                "url":  { "@id": "publication:url",  "@type": "@id" }
+                "name": {
+                    "@id": "publication:name",
+                    "@type": "xsd:string"
+                },
+                "url": {
+                    "@id": "publication:url",
+                    "@type": "@id"
+                }
             }
         },
         "Preprint": {
             "@id": "publication:Preprint",
             "@context": {
-                "where": { "@id": "publication:preprint-where", "@type": "xsd:string" },
-                "url":   { "@id": "publication:url",            "@type": "@id" }
+                "where": {
+                    "@id": "publication:preprint-where",
+                    "@type": "xsd:string"
+                },
+                "url": {
+                    "@id": "publication:url",
+                    "@type": "@id"
+                }
             }
         },
-        "PersonRef":   { "@id": "publication:PersonRef" },
-
-        "name":           { "@id": "publication:name",           "@type": "xsd:string" },
-        "bib-id":         { "@id": "publication:bib-id",         "@type": "xsd:string" },
-        "date-published": { "@id": "publication:date-published", "@type": "xsd:date" },
-        "url":            { "@id": "publication:url",            "@type": "@id" },
-        "doi":            { "@id": "publication:doi",            "@type": "@id" },
-        "website":        { "@id": "publication:website",        "@type": "@id" },
-
+        "name": {
+            "@id": "publication:name",
+            "@type": "xsd:string"
+        },
+        "bib-id": {
+            "@id": "publication:bib-id",
+            "@type": "xsd:string"
+        },
+        "date-published": {
+            "@id": "publication:date-published",
+            "@type": "xsd:date"
+        },
+        "url": {
+            "@id": "publication:url",
+            "@type": "@id"
+        },
+        "doi": {
+            "@id": "publication:doi",
+            "@type": "@id"
+        },
+        "website": {
+            "@id": "publication:website",
+            "@type": "@id"
+        },
         "author": {
-            "@id":        "publication:author",
-            "@type":      "@id",
-            "@container": "@set"
+            "@id": "publication:author",
+            "@type": "@id",
+            "@container": "@set",
+            "@context": {
+                "@vocab": "https://secorolab.github.io/people/"
+            }
         },
-
-        "published-in": { "@id": "publication:published-in", "@type": "@id" },
-        "preprint":     { "@id": "publication:preprint",     "@type": "@id" },
-
+        "published-in": {
+            "@id": "publication:published-in",
+            "@type": "@id"
+        },
+        "preprint": {
+            "@id": "publication:preprint",
+            "@type": "@id"
+        },
         "related-tools": {
-            "@id":        "publication:related-tools",
-            "@type":      "@id",
-            "@container": "@set"
+            "@id": "publication:related-tools",
+            "@type": "@vocab",
+            "@container": "@set",
+            "@context": {
+                "@vocab": "https://secorolab.github.io/tools/"
+            }
         },
-
         "about": {
-            "@id":        "publication:about",
-            "@type":      "@id",
+            "@id": "publication:about",
+            "@type": "@id",
             "@container": "@set"
         }
     }

--- a/website/publication.ttl
+++ b/website/publication.ttl
@@ -128,17 +128,3 @@ sh_sec:PreprintShape
     ] ;
 .
 
-sh_sec:PublicationPersonRefShape
-    a sh:NodeShape ;
-    sh:targetClass publication:PersonRef ;
-    sh:closed false ;
-
-    sh:property [
-        sh:path     publication:name ;
-        sh:datatype xsd:string ;
-        sh:minCount 1 ;
-        sh:maxCount 1 ;
-        sh:severity sh:Violation ;
-        sh:message  "Author reference must have a name." ;
-    ] ;
-.

--- a/website/research-area.json
+++ b/website/research-area.json
@@ -1,18 +1,33 @@
 {
     "@context": {
+        "@base": "https://secorolab.github.io/",
         "xsd": "http://www.w3.org/2001/XMLSchema#",
         "research-area": "https://secorolab.github.io/metamodels/website/research-area#",
-
-        "ResearchArea":      { "@id": "research-area:ResearchArea" },
-        "ResearchObjective": { "@id": "research-area:ResearchObjective" },
-
-        "name":        { "@id": "research-area:name",        "@type": "xsd:string" },
-        "description": { "@id": "research-area:description", "@type": "xsd:string" },
-        "acronym":     { "@id": "research-area:acronym",     "@type": "xsd:string" },
+        "ResearchArea": {
+            "@id": "research-area:ResearchArea"
+        },
+        "ResearchObjective": {
+            "@id": "research-area:ResearchObjective"
+        },
+        "name": {
+            "@id": "research-area:name",
+            "@type": "xsd:string"
+        },
+        "description": {
+            "@id": "research-area:description",
+            "@type": "xsd:string"
+        },
+        "acronym": {
+            "@id": "research-area:acronym",
+            "@type": "xsd:string"
+        },
         "topics": {
-            "@id":       "research-area:topics",
-            "@type":     "@id",
-            "@container": "@set"
+            "@id": "research-area:topics",
+            "@type": "@vocab",
+            "@container": "@set",
+            "@context": {
+                "@vocab": "https://secorolab.github.io/research/"
+            }
         }
     }
 }

--- a/website/research-area.json
+++ b/website/research-area.json
@@ -3,27 +3,16 @@
         "@base": "https://secorolab.github.io/",
         "xsd": "http://www.w3.org/2001/XMLSchema#",
         "research-area": "https://secorolab.github.io/metamodels/website/research-area#",
-        "ResearchArea": {
-            "@id": "research-area:ResearchArea"
-        },
-        "ResearchObjective": {
-            "@id": "research-area:ResearchObjective"
-        },
-        "name": {
-            "@id": "research-area:name",
-            "@type": "xsd:string"
-        },
-        "description": {
-            "@id": "research-area:description",
-            "@type": "xsd:string"
-        },
-        "acronym": {
-            "@id": "research-area:acronym",
-            "@type": "xsd:string"
-        },
+
+        "ResearchArea":      { "@id": "research-area:ResearchArea" },
+        "ResearchObjective": { "@id": "research-area:ResearchObjective" },
+
+        "name":        { "@id": "research-area:name",        "@type": "xsd:string" },
+        "description": { "@id": "research-area:description", "@type": "xsd:string" },
+        "acronym":     { "@id": "research-area:acronym",     "@type": "xsd:string" },
         "topics": {
-            "@id": "research-area:topics",
-            "@type": "@vocab",
+            "@id":       "research-area:topics",
+            "@type":     "@vocab",
             "@container": "@set",
             "@context": {
                 "@vocab": "https://secorolab.github.io/research/"

--- a/website/robot.json
+++ b/website/robot.json
@@ -1,20 +1,45 @@
 {
     "@context": {
+        "@base": "https://secorolab.github.io/",
         "xsd": "http://www.w3.org/2001/XMLSchema#",
         "robot": "https://secorolab.github.io/metamodels/website/robot#",
-
-        "Robot": { "@id": "robot:Robot" },
-        "Brand": { "@id": "robot:Brand" },
-
-        "name":        { "@id": "robot:name",        "@type": "xsd:string" },
-        "description": { "@id": "robot:description", "@type": "xsd:string" },
-        "image":       { "@id": "robot:image",       "@type": "@id" },
-        "url":         { "@id": "robot:url",         "@type": "@id" },
-        "model":       { "@id": "robot:model",       "@type": "xsd:string" },
-        "weight":      { "@id": "robot:weight",      "@type": "xsd:string" },
-
-        "brand":        { "@id": "robot:brand",        "@type": "@id" },
-        "brand-name":   { "@id": "robot:brand-name",   "@type": "xsd:string" },
-        "manufacturer": { "@id": "robot:manufacturer", "@type": "@id" }
+        "Robot": {
+            "@id": "robot:Robot"
+        },
+        "Brand": {
+            "@id": "robot:Brand"
+        },
+        "name": {
+            "@id": "robot:name",
+            "@type": "xsd:string"
+        },
+        "description": {
+            "@id": "robot:description",
+            "@type": "xsd:string"
+        },
+        "url": {
+            "@id": "robot:url",
+            "@type": "@id"
+        },
+        "model": {
+            "@id": "robot:model",
+            "@type": "xsd:string"
+        },
+        "weight": {
+            "@id": "robot:weight",
+            "@type": "xsd:string"
+        },
+        "brand": {
+            "@id": "robot:brand",
+            "@type": "@id"
+        },
+        "brand-name": {
+            "@id": "robot:brand-name",
+            "@type": "xsd:string"
+        },
+        "manufacturer": {
+            "@id": "robot:manufacturer",
+            "@type": "@id"
+        }
     }
 }

--- a/website/robot.json
+++ b/website/robot.json
@@ -3,43 +3,18 @@
         "@base": "https://secorolab.github.io/",
         "xsd": "http://www.w3.org/2001/XMLSchema#",
         "robot": "https://secorolab.github.io/metamodels/website/robot#",
-        "Robot": {
-            "@id": "robot:Robot"
-        },
-        "Brand": {
-            "@id": "robot:Brand"
-        },
-        "name": {
-            "@id": "robot:name",
-            "@type": "xsd:string"
-        },
-        "description": {
-            "@id": "robot:description",
-            "@type": "xsd:string"
-        },
-        "url": {
-            "@id": "robot:url",
-            "@type": "@id"
-        },
-        "model": {
-            "@id": "robot:model",
-            "@type": "xsd:string"
-        },
-        "weight": {
-            "@id": "robot:weight",
-            "@type": "xsd:string"
-        },
-        "brand": {
-            "@id": "robot:brand",
-            "@type": "@id"
-        },
-        "brand-name": {
-            "@id": "robot:brand-name",
-            "@type": "xsd:string"
-        },
-        "manufacturer": {
-            "@id": "robot:manufacturer",
-            "@type": "@id"
-        }
+
+        "Robot": { "@id": "robot:Robot" },
+        "Brand": { "@id": "robot:Brand" },
+
+        "name":        { "@id": "robot:name",        "@type": "xsd:string" },
+        "description": { "@id": "robot:description", "@type": "xsd:string" },
+        "url":         { "@id": "robot:url",         "@type": "@id" },
+        "model":       { "@id": "robot:model",       "@type": "xsd:string" },
+        "weight":      { "@id": "robot:weight",      "@type": "xsd:string" },
+
+        "brand":        { "@id": "robot:brand",        "@type": "@id" },
+        "brand-name":   { "@id": "robot:brand-name",   "@type": "xsd:string" },
+        "manufacturer": { "@id": "robot:manufacturer", "@type": "@id" }
     }
 }

--- a/website/robot.ttl
+++ b/website/robot.ttl
@@ -26,11 +26,6 @@ sh_sec:RobotShape
         sh:message  "Robot should have a description." ;
     ] ;
 
-    sh:property [
-        sh:path     robot:image ;
-        sh:nodeKind sh:IRI ;
-        sh:maxCount 1 ;
-    ] ;
 
     sh:property [
         sh:path     robot:url ;

--- a/website/thesis.json
+++ b/website/thesis.json
@@ -3,45 +3,24 @@
         "@base": "https://secorolab.github.io/",
         "xsd": "http://www.w3.org/2001/XMLSchema#",
         "thesis": "https://secorolab.github.io/metamodels/website/thesis#",
-        "Thesis": {
-            "@id": "thesis:Thesis"
-        },
-        "name": {
-            "@id": "thesis:name",
-            "@type": "xsd:string"
-        },
-        "description": {
-            "@id": "thesis:description",
-            "@type": "xsd:string"
-        },
-        "date-published": {
-            "@id": "thesis:date-published",
-            "@type": "xsd:date"
-        },
-        "educational-level": {
-            "@id": "thesis:educational-level",
-            "@type": "xsd:string"
-        },
-        "in-support-of": {
-            "@id": "thesis:in-support-of",
-            "@type": "xsd:string"
-        },
-        "url": {
-            "@id": "thesis:url",
-            "@type": "@id"
-        },
-        "author": {
-            "@id": "thesis:author",
-            "@type": "@id"
-        },
+
+        "Thesis":    { "@id": "thesis:Thesis" },
+
+        "name":              { "@id": "thesis:name",              "@type": "xsd:string" },
+        "description":       { "@id": "thesis:description",       "@type": "xsd:string" },
+        "date-published":    { "@id": "thesis:date-published",    "@type": "xsd:date" },
+        "educational-level": { "@id": "thesis:educational-level", "@type": "xsd:string" },
+        "in-support-of":     { "@id": "thesis:in-support-of",     "@type": "xsd:string" },
+        "url":               { "@id": "thesis:url",               "@type": "@id" },
+
+        "author": { "@id": "thesis:author", "@type": "@id" },
+
         "advisor": {
-            "@id": "thesis:advisor",
-            "@type": "@id",
+            "@id":        "thesis:advisor",
+            "@type":      "@id",
             "@container": "@set"
         },
-        "source-organization": {
-            "@id": "thesis:source-organization",
-            "@type": "@id"
-        }
+
+        "source-organization": { "@id": "thesis:source-organization", "@type": "@id" }
     }
 }

--- a/website/thesis.json
+++ b/website/thesis.json
@@ -1,26 +1,47 @@
 {
     "@context": {
+        "@base": "https://secorolab.github.io/",
         "xsd": "http://www.w3.org/2001/XMLSchema#",
         "thesis": "https://secorolab.github.io/metamodels/website/thesis#",
-
-        "Thesis":    { "@id": "thesis:Thesis" },
-        "PersonRef": { "@id": "thesis:PersonRef" },
-
-        "name":              { "@id": "thesis:name",              "@type": "xsd:string" },
-        "description":       { "@id": "thesis:description",       "@type": "xsd:string" },
-        "date-published":    { "@id": "thesis:date-published",    "@type": "xsd:date" },
-        "educational-level": { "@id": "thesis:educational-level", "@type": "xsd:string" },
-        "in-support-of":     { "@id": "thesis:in-support-of",     "@type": "xsd:string" },
-        "url":               { "@id": "thesis:url",               "@type": "@id" },
-
-        "author": { "@id": "thesis:author", "@type": "@id" },
-
+        "Thesis": {
+            "@id": "thesis:Thesis"
+        },
+        "name": {
+            "@id": "thesis:name",
+            "@type": "xsd:string"
+        },
+        "description": {
+            "@id": "thesis:description",
+            "@type": "xsd:string"
+        },
+        "date-published": {
+            "@id": "thesis:date-published",
+            "@type": "xsd:date"
+        },
+        "educational-level": {
+            "@id": "thesis:educational-level",
+            "@type": "xsd:string"
+        },
+        "in-support-of": {
+            "@id": "thesis:in-support-of",
+            "@type": "xsd:string"
+        },
+        "url": {
+            "@id": "thesis:url",
+            "@type": "@id"
+        },
+        "author": {
+            "@id": "thesis:author",
+            "@type": "@id"
+        },
         "advisor": {
-            "@id":        "thesis:advisor",
-            "@type":      "@id",
+            "@id": "thesis:advisor",
+            "@type": "@id",
             "@container": "@set"
         },
-
-        "source-organization": { "@id": "thesis:source-organization", "@type": "@id" }
+        "source-organization": {
+            "@id": "thesis:source-organization",
+            "@type": "@id"
+        }
     }
 }

--- a/website/thesis.ttl
+++ b/website/thesis.ttl
@@ -74,17 +74,3 @@ sh_sec:ThesisShape
     ] ;
 .
 
-sh_sec:ThesisPersonRefShape
-    a sh:NodeShape ;
-    sh:targetClass thesis:PersonRef ;
-    sh:closed false ;
-
-    sh:property [
-        sh:path     thesis:name ;
-        sh:datatype xsd:string ;
-        sh:minCount 1 ;
-        sh:maxCount 1 ;
-        sh:severity sh:Violation ;
-        sh:message  "Person reference must have a name." ;
-    ] ;
-.

--- a/website/tool.json
+++ b/website/tool.json
@@ -1,34 +1,65 @@
 {
     "@context": {
+        "@base": "https://secorolab.github.io/",
         "xsd": "http://www.w3.org/2001/XMLSchema#",
         "tool": "https://secorolab.github.io/metamodels/website/tool#",
-
-        "Tool":        { "@id": "tool:Tool" },
-        "DemoVideo":   { "@id": "tool:DemoVideo" },
-
-        "name":                 { "@id": "tool:name",                 "@type": "xsd:string" },
-        "description":          { "@id": "tool:description",          "@type": "xsd:string" },
-        "url":                  { "@id": "tool:url",                  "@type": "@id" },
-        "external-url":         { "@id": "tool:external-url",         "@type": "@id" },
-        "code-url":             { "@id": "tool:code-url",             "@type": "@id" },
-        "website-url":          { "@id": "tool:website-url",          "@type": "@id" },
-        "paper-url":            { "@id": "tool:paper-url",            "@type": "@id" },
-        "related-publications": {
-            "@id":        "tool:related-publications",
-            "@type":      "@id",
-            "@container": "@set"
+        "Tool": {
+            "@id": "tool:Tool"
         },
-        "application-category": { "@id": "tool:application-category", "@type": "xsd:string" },
-
-        "video": { "@id": "tool:video", "@type": "@id" },
-
-        "video-name": { "@id": "tool:video-name", "@type": "xsd:string" },
-        "video-url":  { "@id": "tool:video-url",  "@type": "@id" },
-
-        "keywords": {
-            "@id":        "tool:keywords",
-            "@type":      "@id",
-            "@container": "@set"
+        "DemoVideo": {
+            "@id": "tool:DemoVideo"
+        },
+        "name": {
+            "@id": "tool:name",
+            "@type": "xsd:string"
+        },
+        "description": {
+            "@id": "tool:description",
+            "@type": "xsd:string"
+        },
+        "url": {
+            "@id": "tool:url",
+            "@type": "@id"
+        },
+        "external-url": {
+            "@id": "tool:external-url",
+            "@type": "@id"
+        },
+        "code-url": {
+            "@id": "tool:code-url",
+            "@type": "@id"
+        },
+        "website-url": {
+            "@id": "tool:website-url",
+            "@type": "@id"
+        },
+        "paper-url": {
+            "@id": "tool:paper-url",
+            "@type": "@id"
+        },
+        "related-publications": {
+            "@id": "tool:related-publications",
+            "@type": "@vocab",
+            "@container": "@set",
+            "@context": {
+                "@vocab": "https://secorolab.github.io/publications/"
+            }
+        },
+        "application-category": {
+            "@id": "tool:application-category",
+            "@type": "xsd:string"
+        },
+        "video": {
+            "@id": "tool:video",
+            "@type": "@id"
+        },
+        "video-name": {
+            "@id": "tool:video-name",
+            "@type": "xsd:string"
+        },
+        "video-url": {
+            "@id": "tool:video-url",
+            "@type": "@id"
         }
     }
 }

--- a/website/tool.json
+++ b/website/tool.json
@@ -3,63 +3,30 @@
         "@base": "https://secorolab.github.io/",
         "xsd": "http://www.w3.org/2001/XMLSchema#",
         "tool": "https://secorolab.github.io/metamodels/website/tool#",
-        "Tool": {
-            "@id": "tool:Tool"
-        },
-        "DemoVideo": {
-            "@id": "tool:DemoVideo"
-        },
-        "name": {
-            "@id": "tool:name",
-            "@type": "xsd:string"
-        },
-        "description": {
-            "@id": "tool:description",
-            "@type": "xsd:string"
-        },
-        "url": {
-            "@id": "tool:url",
-            "@type": "@id"
-        },
-        "external-url": {
-            "@id": "tool:external-url",
-            "@type": "@id"
-        },
-        "code-url": {
-            "@id": "tool:code-url",
-            "@type": "@id"
-        },
-        "website-url": {
-            "@id": "tool:website-url",
-            "@type": "@id"
-        },
-        "paper-url": {
-            "@id": "tool:paper-url",
-            "@type": "@id"
-        },
+
+        "Tool":        { "@id": "tool:Tool" },
+        "DemoVideo":   { "@id": "tool:DemoVideo" },
+
+        "name":                 { "@id": "tool:name",                 "@type": "xsd:string" },
+        "description":          { "@id": "tool:description",          "@type": "xsd:string" },
+        "url":                  { "@id": "tool:url",                  "@type": "@id" },
+        "external-url":         { "@id": "tool:external-url",         "@type": "@id" },
+        "code-url":             { "@id": "tool:code-url",             "@type": "@id" },
+        "website-url":          { "@id": "tool:website-url",          "@type": "@id" },
+        "paper-url":            { "@id": "tool:paper-url",            "@type": "@id" },
         "related-publications": {
-            "@id": "tool:related-publications",
-            "@type": "@vocab",
+            "@id":        "tool:related-publications",
+            "@type":      "@vocab",
             "@container": "@set",
             "@context": {
                 "@vocab": "https://secorolab.github.io/publications/"
             }
         },
-        "application-category": {
-            "@id": "tool:application-category",
-            "@type": "xsd:string"
-        },
-        "video": {
-            "@id": "tool:video",
-            "@type": "@id"
-        },
-        "video-name": {
-            "@id": "tool:video-name",
-            "@type": "xsd:string"
-        },
-        "video-url": {
-            "@id": "tool:video-url",
-            "@type": "@id"
-        }
+        "application-category": { "@id": "tool:application-category", "@type": "xsd:string" },
+
+        "video": { "@id": "tool:video", "@type": "@id" },
+
+        "video-name": { "@id": "tool:video-name", "@type": "xsd:string" },
+        "video-url":  { "@id": "tool:video-url",  "@type": "@id" }
     }
 }

--- a/website/tool.ttl
+++ b/website/tool.ttl
@@ -2,6 +2,7 @@
 @prefix xsd:    <http://www.w3.org/2001/XMLSchema#> .
 @prefix sh_sec: <https://secorolab.github.io/metamodels/website/> .
 @prefix tool:   <https://secorolab.github.io/metamodels/website/tool#> .
+@prefix kw:     <https://secorolab.github.io/metamodels/website/keyword#> .
 
 sh_sec:ToolShape
     a sh:NodeShape ;
@@ -72,13 +73,13 @@ sh_sec:ToolShape
         sh:nodeKind sh:BlankNodeOrIRI ;
         sh:maxCount 1 ;
     ] ;
-
     sh:property [
-        sh:path     tool:keywords ;
+        sh:path     kw:keywords ;
         sh:nodeKind sh:IRI ;
         sh:severity sh:Warning ;
         sh:message  "Tool keywords should reference keyword IRIs." ;
     ] ;
+
 .
 
 sh_sec:DemoVideoShape


### PR DESCRIPTION
## Summary
- Add shared `image`, `keyword`, and `person-ref` metamodels (JSON + TTL shapes)
- Add `@base` context to all website JSON-LD files
- Remove `logo` property from partner and project models (moved to image model)
- Remove `image` property from robot model (moved to image model)
- Move `PersonRef` from publication/thesis to its own dedicated model
- Move `keywords` from news/tool context to keyword namespace with `@vocab` references
- Change `@type` from `@id` to `@vocab` for `member`, `topics`, and `related-publications` with scoped contexts
- Remove `publication:PersonRef`, `thesis:PersonRef`, and `thesis:PersonRef` TTL shapes (replaced by shared `person-ref` model)