### PR TITLE
Add robot DSL support metamodels

### DIFF
--- a/kinematic-chain/structural-entities-extension.json
+++ b/kinematic-chain/structural-entities-extension.json
@@ -4,6 +4,8 @@
         "xsd": "http://www.w3.org/2001/XMLSchema#",
         "kc-ext": "https://secorolab.github.io/metamodels/kinematic-chain/structural-entities-extension#",
 
+        "Scleronomic": "kc-ext:Scleronomic",
+
         "JointLimit": {
             "@id": "kc-ext:JointLimit",
             "@context": {
@@ -20,15 +22,15 @@
             }
         },
 
-        "MimicJointRelation": {
-            "@id": "kc-ext:MimicJointRelation",
+        "JointCoupling": {
+            "@id": "kc-ext:JointCoupling",
             "@context": {
-                "mimicking-joint": {
-                    "@id": "kc-ext:mimicking-joint",
+                "independent-joint": {
+                    "@id": "kc-ext:independent-joint",
                     "@type": "@id"
                 },
-                "mimicked-joint": {
-                    "@id": "kc-ext:mimicked-joint",
+                "dependent-joint": {
+                    "@id": "kc-ext:dependent-joint",
                     "@type": "@id"
                 },
                 "multiplier": {
@@ -36,8 +38,7 @@
                     "@type": "xsd:double"
                 },
                 "offset": {
-                    "@id": "kc-ext:offset",
-                    "@type": "xsd:double"
+                    "@id": "kc-ext:offset"
                 }
             }
         }

--- a/kinematic-chain/structural-entities-extension.json
+++ b/kinematic-chain/structural-entities-extension.json
@@ -2,7 +2,6 @@
     "@context": {
         "@version": 1.1,
         "xsd": "http://www.w3.org/2001/XMLSchema#",
-        "qudt-schema": "http://qudt.org/schema/qudt/",
         "kc-ext": "https://secorolab.github.io/metamodels/kinematic-chain/structural-entities-extension#",
 
         "JointLimit": {
@@ -12,21 +11,11 @@
                     "@id": "kc-ext:of-joint",
                     "@type": "@id"
                 },
-                "limit-kind": {
-                    "@id": "kc-ext:limit-kind",
-                    "@type": "@id"
-                },
                 "lower": {
-                    "@id": "kc-ext:lower",
-                    "@type": "xsd:double"
+                    "@id": "kc-ext:lower"
                 },
                 "upper": {
-                    "@id": "kc-ext:upper",
-                    "@type": "xsd:double"
-                },
-                "unit": {
-                    "@id": "qudt-schema:unit",
-                    "@type": "@id"
+                    "@id": "kc-ext:upper"
                 }
             }
         },
@@ -49,10 +38,6 @@
                 "offset": {
                     "@id": "kc-ext:offset",
                     "@type": "xsd:double"
-                },
-                "offset-unit": {
-                    "@id": "kc-ext:offset-unit",
-                    "@type": "@id"
                 }
             }
         }

--- a/kinematic-chain/structural-entities-extension.json
+++ b/kinematic-chain/structural-entities-extension.json
@@ -1,0 +1,60 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "xsd": "http://www.w3.org/2001/XMLSchema#",
+        "qudt-schema": "http://qudt.org/schema/qudt/",
+        "kc-ext": "https://secorolab.github.io/metamodels/kinematic-chain/structural-entities-extension#",
+
+        "JointLimit": {
+            "@id": "kc-ext:JointLimit",
+            "@context": {
+                "of-joint": {
+                    "@id": "kc-ext:of-joint",
+                    "@type": "@id"
+                },
+                "limit-kind": {
+                    "@id": "kc-ext:limit-kind",
+                    "@type": "@id"
+                },
+                "lower": {
+                    "@id": "kc-ext:lower",
+                    "@type": "xsd:double"
+                },
+                "upper": {
+                    "@id": "kc-ext:upper",
+                    "@type": "xsd:double"
+                },
+                "unit": {
+                    "@id": "qudt-schema:unit",
+                    "@type": "@id"
+                }
+            }
+        },
+
+        "MimicJointRelation": {
+            "@id": "kc-ext:MimicJointRelation",
+            "@context": {
+                "mimicking-joint": {
+                    "@id": "kc-ext:mimicking-joint",
+                    "@type": "@id"
+                },
+                "mimicked-joint": {
+                    "@id": "kc-ext:mimicked-joint",
+                    "@type": "@id"
+                },
+                "multiplier": {
+                    "@id": "kc-ext:multiplier",
+                    "@type": "xsd:double"
+                },
+                "offset": {
+                    "@id": "kc-ext:offset",
+                    "@type": "xsd:double"
+                },
+                "offset-unit": {
+                    "@id": "kc-ext:offset-unit",
+                    "@type": "@id"
+                }
+            }
+        }
+    }
+}

--- a/kinematic-chain/structural-entities-extension.shacl.ttl
+++ b/kinematic-chain/structural-entities-extension.shacl.ttl
@@ -1,15 +1,30 @@
 # SPDX-License-Identifier: MPL-2.0
 # SPDX-FileCopyrightText: 2026 SECORO AG (secoro.uni-bremen.de)
 # Author: Vamsi Kalagaturu
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix qudt: <http://qudt.org/schema/qudt/> .
 @prefix kc: <https://comp-rob2b.github.io/metamodels/kinematic-chain/structural-entities#> .
+@prefix kc-stat: <https://comp-rob2b.github.io/metamodels/kinematic-chain/state#> .
 @prefix kc-ext: <https://secorolab.github.io/metamodels/kinematic-chain/structural-entities-extension#> .
 
 kc-ext:JointLimitShape
   a sh:NodeShape ;
   sh:targetClass kc-ext:JointLimit ;
+  sh:property [
+    sh:path rdf:type ;
+    sh:qualifiedValueShape [
+      sh:in (
+        kc-stat:JointPosition
+        kc-stat:JointVelocity
+        kc-stat:JointAcceleration
+        kc-stat:JointForce
+      ) ;
+    ] ;
+    sh:qualifiedMinCount 1 ;
+    sh:qualifiedMaxCount 1 ;
+  ] ;
   sh:property [
     sh:path kc-ext:of-joint ;
     sh:class kc:Joint ;
@@ -17,21 +32,90 @@ kc-ext:JointLimitShape
     sh:maxCount 1 ;
   ] ;
   sh:property [
-    sh:path kc-ext:limit-kind ;
-    sh:in (kc-ext:position kc-ext:velocity kc-ext:acceleration kc-ext:effort) ;
-    sh:minCount 1 ;
-    sh:maxCount 1 ;
-  ] ;
-  sh:property [
     sh:path kc-ext:lower ;
-    sh:datatype xsd:double ;
-    sh:lessThanOrEquals kc-ext:upper ;
+    sh:node kc-ext:JointLimitValueShape ;
     sh:minCount 1 ;
     sh:maxCount 1 ;
   ] ;
   sh:property [
     sh:path kc-ext:upper ;
-    sh:datatype xsd:double ;
+    sh:node kc-ext:JointLimitValueShape ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+  ] ;
+  sh:sparql [
+    sh:message "Lower value must not exceed upper value." ;
+    sh:select """
+      PREFIX kc-ext: <https://secorolab.github.io/metamodels/kinematic-chain/structural-entities-extension#>
+      PREFIX qudt: <http://qudt.org/schema/qudt/>
+      SELECT $this WHERE {
+        $this kc-ext:lower/qudt:value ?lower ;
+              kc-ext:upper/qudt:value ?upper .
+        FILTER (?lower > ?upper)
+      }
+    """ ;
+  ] ;
+  sh:sparql [
+    sh:message "Lower and upper values must use the same unit." ;
+    sh:select """
+      PREFIX kc-ext: <https://secorolab.github.io/metamodels/kinematic-chain/structural-entities-extension#>
+      PREFIX qudt: <http://qudt.org/schema/qudt/>
+      SELECT $this WHERE {
+        $this kc-ext:lower/qudt:unit ?lowerUnit ;
+              kc-ext:upper/qudt:unit ?upperUnit .
+        FILTER (?lowerUnit != ?upperUnit)
+      }
+    """ ;
+  ] ;
+  sh:sparql [
+    sh:message "Lower and upper values must use the same quantity kind." ;
+    sh:select """
+      PREFIX kc-ext: <https://secorolab.github.io/metamodels/kinematic-chain/structural-entities-extension#>
+      PREFIX qudt: <http://qudt.org/schema/qudt/>
+      SELECT $this WHERE {
+        $this kc-ext:lower/qudt:hasQuantityKind ?lowerKind ;
+              kc-ext:upper/qudt:hasQuantityKind ?upperKind .
+        FILTER (?lowerKind != ?upperKind)
+      }
+    """ ;
+  ] ;
+  sh:sparql [
+    sh:message "Quantity kind must match the joint limit type." ;
+    sh:select """
+      PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+      PREFIX qudt: <http://qudt.org/schema/qudt/>
+      PREFIX kc-stat: <https://comp-rob2b.github.io/metamodels/kinematic-chain/state#>
+      PREFIX kc-ext: <https://secorolab.github.io/metamodels/kinematic-chain/structural-entities-extension#>
+      PREFIX quantitykind: <http://qudt.org/vocab/quantitykind/>
+      SELECT $this WHERE {
+        $this rdf:type ?limitType ;
+              kc-ext:lower/qudt:hasQuantityKind ?kind .
+        FILTER (
+          (?limitType = kc-stat:JointPosition &&
+            ?kind NOT IN (quantitykind:Angle, quantitykind:Length)) ||
+          (?limitType = kc-stat:JointVelocity &&
+            ?kind NOT IN (quantitykind:AngularVelocity, quantitykind:LinearVelocity)) ||
+          (?limitType = kc-stat:JointAcceleration &&
+            ?kind NOT IN (quantitykind:AngularAcceleration, quantitykind:LinearAcceleration)) ||
+          (?limitType = kc-stat:JointForce &&
+            ?kind NOT IN (quantitykind:Torque, quantitykind:Force))
+        )
+      }
+    """ ;
+  ] .
+
+kc-ext:JointLimitValueShape
+  a sh:NodeShape ;
+  sh:class qudt:Quantity ;
+  sh:property [
+    sh:path qudt:hasQuantityKind ;
+    sh:nodeKind sh:IRI ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+  ] ;
+  sh:property [
+    sh:path qudt:value ;
+    sh:nodeKind sh:Literal ;
     sh:minCount 1 ;
     sh:maxCount 1 ;
   ] ;
@@ -70,7 +154,7 @@ kc-ext:MimicJointRelationShape
     sh:maxCount 1 ;
   ] ;
   sh:property [
-    sh:path kc-ext:offset-unit ;
+    sh:path qudt:unit ;
     sh:nodeKind sh:IRI ;
     sh:minCount 1 ;
     sh:maxCount 1 ;
@@ -78,6 +162,7 @@ kc-ext:MimicJointRelationShape
   sh:sparql [
     sh:message "A mimic relation must not point a joint at itself." ;
     sh:select """
+      PREFIX kc-ext: <https://secorolab.github.io/metamodels/kinematic-chain/structural-entities-extension#>
       SELECT $this WHERE {
         $this kc-ext:mimicking-joint ?joint ;
               kc-ext:mimicked-joint ?joint .

--- a/kinematic-chain/structural-entities-extension.shacl.ttl
+++ b/kinematic-chain/structural-entities-extension.shacl.ttl
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: 2026 SECORO AG (secoro.uni-bremen.de)
 # Author: Vamsi Kalagaturu
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix qudt: <http://qudt.org/schema/qudt/> .
@@ -33,13 +34,13 @@ kc-ext:JointLimitShape
   ] ;
   sh:property [
     sh:path kc-ext:lower ;
-    sh:node kc-ext:JointLimitValueShape ;
+    sh:node kc-ext:QuantityValueShape ;
     sh:minCount 1 ;
     sh:maxCount 1 ;
   ] ;
   sh:property [
     sh:path kc-ext:upper ;
-    sh:node kc-ext:JointLimitValueShape ;
+    sh:node kc-ext:QuantityValueShape ;
     sh:minCount 1 ;
     sh:maxCount 1 ;
   ] ;
@@ -104,7 +105,7 @@ kc-ext:JointLimitShape
     """ ;
   ] .
 
-kc-ext:JointLimitValueShape
+kc-ext:QuantityValueShape
   a sh:NodeShape ;
   sh:class qudt:Quantity ;
   sh:property [
@@ -126,17 +127,29 @@ kc-ext:JointLimitValueShape
     sh:maxCount 1 ;
   ] .
 
-kc-ext:MimicJointRelationShape
+kc-ext:Scleronomic
+  a rdfs:Class ;
+  rdfs:comment "A scleronomic constraint: a holonomic equality constraint phi(q1..qn) = 0, a function of joint position variables only (Featherstone, Rigid Body Dynamics Algorithms, sec. 3.4)." .
+
+kc-ext:JointCoupling
+  rdfs:subClassOf kc-ext:Scleronomic .
+
+kc-ext:JointCouplingShape
   a sh:NodeShape ;
-  sh:targetClass kc-ext:MimicJointRelation ;
+  sh:targetClass kc-ext:JointCoupling ;
   sh:property [
-    sh:path kc-ext:mimicking-joint ;
+    sh:path rdf:type ;
+    sh:hasValue kc-ext:Scleronomic ;
+    sh:message "A joint coupling must be typed as a scleronomic constraint (kc-ext:Scleronomic)." ;
+  ] ;
+  sh:property [
+    sh:path kc-ext:independent-joint ;
     sh:class kc:Joint ;
     sh:minCount 1 ;
     sh:maxCount 1 ;
   ] ;
   sh:property [
-    sh:path kc-ext:mimicked-joint ;
+    sh:path kc-ext:dependent-joint ;
     sh:class kc:Joint ;
     sh:minCount 1 ;
     sh:maxCount 1 ;
@@ -149,23 +162,42 @@ kc-ext:MimicJointRelationShape
   ] ;
   sh:property [
     sh:path kc-ext:offset ;
-    sh:datatype xsd:double ;
-    sh:minCount 1 ;
-    sh:maxCount 1 ;
-  ] ;
-  sh:property [
-    sh:path qudt:unit ;
-    sh:nodeKind sh:IRI ;
+    sh:node kc-ext:QuantityValueShape ;
     sh:minCount 1 ;
     sh:maxCount 1 ;
   ] ;
   sh:sparql [
-    sh:message "A mimic relation must not point a joint at itself." ;
+    sh:message "A joint coupling must not couple a joint to itself." ;
     sh:select """
       PREFIX kc-ext: <https://secorolab.github.io/metamodels/kinematic-chain/structural-entities-extension#>
       SELECT $this WHERE {
-        $this kc-ext:mimicking-joint ?joint ;
-              kc-ext:mimicked-joint ?joint .
+        $this kc-ext:independent-joint ?joint ;
+              kc-ext:dependent-joint ?joint .
+      }
+    """ ;
+  ] ;
+  sh:sparql [
+    sh:message "A joint coupling must have a non-zero multiplier (zero locks the dependent joint)." ;
+    sh:select """
+      PREFIX kc-ext: <https://secorolab.github.io/metamodels/kinematic-chain/structural-entities-extension#>
+      SELECT $this WHERE {
+        $this kc-ext:multiplier ?ratio .
+        FILTER (?ratio = 0.0)
+      }
+    """ ;
+  ] ;
+  sh:sparql [
+    sh:message "Independent and dependent joints of a coupling must share the same position quantity kind." ;
+    sh:select """
+      PREFIX kc-ext: <https://secorolab.github.io/metamodels/kinematic-chain/structural-entities-extension#>
+      PREFIX kc-stat: <https://comp-rob2b.github.io/metamodels/kinematic-chain/state#>
+      PREFIX qudt: <http://qudt.org/schema/qudt/>
+      SELECT $this WHERE {
+        $this kc-ext:independent-joint ?ji ;
+              kc-ext:dependent-joint ?jd .
+        ?pi a kc-stat:JointPosition ; kc-stat:of-joint ?ji ; qudt:hasQuantityKind ?ki .
+        ?pd a kc-stat:JointPosition ; kc-stat:of-joint ?jd ; qudt:hasQuantityKind ?kd .
+        FILTER (?ki != ?kd)
       }
     """ ;
   ] .

--- a/kinematic-chain/structural-entities-extension.shacl.ttl
+++ b/kinematic-chain/structural-entities-extension.shacl.ttl
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: MPL-2.0
+# SPDX-FileCopyrightText: 2026 SECORO AG (secoro.uni-bremen.de)
+# Author: Vamsi Kalagaturu
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix qudt: <http://qudt.org/schema/qudt/> .
+@prefix kc: <https://comp-rob2b.github.io/metamodels/kinematic-chain/structural-entities#> .
+@prefix kc-ext: <https://secorolab.github.io/metamodels/kinematic-chain/structural-entities-extension#> .
+
+kc-ext:JointLimitShape
+  a sh:NodeShape ;
+  sh:targetClass kc-ext:JointLimit ;
+  sh:property [
+    sh:path kc-ext:of-joint ;
+    sh:class kc:Joint ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+  ] ;
+  sh:property [
+    sh:path kc-ext:limit-kind ;
+    sh:in (kc-ext:position kc-ext:velocity kc-ext:acceleration kc-ext:effort) ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+  ] ;
+  sh:property [
+    sh:path kc-ext:lower ;
+    sh:datatype xsd:double ;
+    sh:lessThanOrEquals kc-ext:upper ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+  ] ;
+  sh:property [
+    sh:path kc-ext:upper ;
+    sh:datatype xsd:double ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+  ] ;
+  sh:property [
+    sh:path qudt:unit ;
+    sh:nodeKind sh:IRI ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+  ] .
+
+kc-ext:MimicJointRelationShape
+  a sh:NodeShape ;
+  sh:targetClass kc-ext:MimicJointRelation ;
+  sh:property [
+    sh:path kc-ext:mimicking-joint ;
+    sh:class kc:Joint ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+  ] ;
+  sh:property [
+    sh:path kc-ext:mimicked-joint ;
+    sh:class kc:Joint ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+  ] ;
+  sh:property [
+    sh:path kc-ext:multiplier ;
+    sh:datatype xsd:double ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+  ] ;
+  sh:property [
+    sh:path kc-ext:offset ;
+    sh:datatype xsd:double ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+  ] ;
+  sh:property [
+    sh:path kc-ext:offset-unit ;
+    sh:nodeKind sh:IRI ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+  ] ;
+  sh:sparql [
+    sh:message "A mimic relation must not point a joint at itself." ;
+    sh:select """
+      SELECT $this WHERE {
+        $this kc-ext:mimicking-joint ?joint ;
+              kc-ext:mimicked-joint ?joint .
+      }
+    """ ;
+  ] .

--- a/robot/actuation.json
+++ b/robot/actuation.json
@@ -18,8 +18,8 @@
                     "@id": "act:actuator",
                     "@type": "@id"
                 },
-                "mechanical-reduction": {
-                    "@id": "act:mechanical-reduction",
+                "gear-ratio": {
+                    "@id": "act:gear-ratio",
                     "@type": "xsd:double"
                 },
                 "command-interface": {

--- a/robot/actuation.json
+++ b/robot/actuation.json
@@ -1,0 +1,48 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "xsd": "http://www.w3.org/2001/XMLSchema#",
+        "act": "https://secorolab.github.io/metamodels/robot/actuation#",
+
+        "Transmission": {
+            "@id": "act:Transmission",
+            "@context": {
+                "joint": {
+                    "@id": "act:joint",
+                    "@type": "@id"
+                },
+                "actuator": {
+                    "@id": "act:actuator",
+                    "@type": "@id"
+                },
+                "mechanical-reduction": {
+                    "@id": "act:mechanical-reduction",
+                    "@type": "xsd:double"
+                },
+                "command-interface": {
+                    "@id": "act:command-interface",
+                    "@type": "@vocab",
+                    "@context": {
+                        "position": "act:position",
+                        "velocity": "act:velocity",
+                        "torque": "act:torque",
+                        "current": "act:current"
+                    }
+                },
+                "state-interface": {
+                    "@id": "act:state-interface",
+                    "@type": "@vocab",
+                    "@container": "@set",
+                    "@context": {
+                        "position": "act:position",
+                        "velocity": "act:velocity",
+                        "torque": "act:torque",
+                        "current": "act:current"
+                    }
+                }
+            }
+        },
+        "Actuator": "act:Actuator",
+        "ElectricCurrentInterface": "act:ElectricCurrentInterface"
+    }
+}

--- a/robot/actuation.json
+++ b/robot/actuation.json
@@ -4,6 +4,10 @@
         "xsd": "http://www.w3.org/2001/XMLSchema#",
         "act": "https://secorolab.github.io/metamodels/robot/actuation#",
 
+        "Actuator": "act:Actuator",
+        "ElectricCurrentInterface": "act:ElectricCurrentInterface",
+        "current": "act:current",
+
         "Transmission": {
             "@id": "act:Transmission",
             "@context": {
@@ -22,27 +26,14 @@
                 "command-interface": {
                     "@id": "act:command-interface",
                     "@type": "@vocab",
-                    "@context": {
-                        "position": "act:position",
-                        "velocity": "act:velocity",
-                        "torque": "act:torque",
-                        "current": "act:current"
-                    }
+                    "@container": "@set"
                 },
                 "state-interface": {
                     "@id": "act:state-interface",
                     "@type": "@vocab",
-                    "@container": "@set",
-                    "@context": {
-                        "position": "act:position",
-                        "velocity": "act:velocity",
-                        "torque": "act:torque",
-                        "current": "act:current"
-                    }
+                    "@container": "@set"
                 }
             }
-        },
-        "Actuator": "act:Actuator",
-        "ElectricCurrentInterface": "act:ElectricCurrentInterface"
+        }
     }
 }

--- a/robot/actuation.json
+++ b/robot/actuation.json
@@ -5,7 +5,6 @@
         "act": "https://secorolab.github.io/metamodels/robot/actuation#",
 
         "Actuator": "act:Actuator",
-        "ElectricCurrentInterface": "act:ElectricCurrentInterface",
         "current": "act:current",
 
         "Transmission": {

--- a/robot/actuation.shacl.ttl
+++ b/robot/actuation.shacl.ttl
@@ -23,7 +23,7 @@ act:TransmissionShape
     sh:maxCount 1 ;
   ] ;
   sh:property [
-    sh:path act:mechanical-reduction ;
+    sh:path act:gear-ratio ;
     sh:datatype xsd:double ;
     sh:minCount 1 ;
     sh:maxCount 1 ;
@@ -39,11 +39,11 @@ act:TransmissionShape
     sh:minCount 1 ;
   ] ;
   sh:sparql [
-    sh:message "A transmission mechanical reduction must be nonzero." ;
+    sh:message "A transmission gear ratio must be nonzero." ;
     sh:select """
       PREFIX act: <https://secorolab.github.io/metamodels/robot/actuation#>
       SELECT $this WHERE {
-        $this act:mechanical-reduction ?value .
+        $this act:gear-ratio ?value .
         FILTER (?value = 0.0)
       }
     """ ;

--- a/robot/actuation.shacl.ttl
+++ b/robot/actuation.shacl.ttl
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: MPL-2.0
+# SPDX-FileCopyrightText: 2026 SECORO AG (secoro.uni-bremen.de)
+# Author: Vamsi Kalagaturu
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix kc: <https://comp-rob2b.github.io/metamodels/kinematic-chain/structural-entities#> .
+@prefix act: <https://secorolab.github.io/metamodels/robot/actuation#> .
+
+act:TransmissionShape
+  a sh:NodeShape ;
+  sh:targetClass act:Transmission ;
+  sh:property [
+    sh:path act:joint ;
+    sh:class kc:Joint ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+  ] ;
+  sh:property [
+    sh:path act:actuator ;
+    sh:class act:Actuator ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+  ] ;
+  sh:property [
+    sh:path act:mechanical-reduction ;
+    sh:datatype xsd:double ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+  ] ;
+  sh:property [
+    sh:path act:command-interface ;
+    sh:in (act:position act:velocity act:torque act:current) ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+  ] ;
+  sh:property [
+    sh:path act:state-interface ;
+    sh:in (act:position act:velocity act:torque act:current) ;
+    sh:minCount 1 ;
+  ] ;
+  sh:sparql [
+    sh:message "A transmission mechanical reduction must be nonzero." ;
+    sh:select """
+      SELECT $this WHERE {
+        $this act:mechanical-reduction ?value .
+        FILTER (?value = 0.0)
+      }
+    """ ;
+  ] .
+
+act:ActuatorShape
+  a sh:NodeShape ;
+  sh:targetClass act:Actuator .

--- a/robot/actuation.shacl.ttl
+++ b/robot/actuation.shacl.ttl
@@ -4,6 +4,7 @@
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix kc: <https://comp-rob2b.github.io/metamodels/kinematic-chain/structural-entities#> .
+@prefix kc-stat: <https://comp-rob2b.github.io/metamodels/kinematic-chain/state#> .
 @prefix act: <https://secorolab.github.io/metamodels/robot/actuation#> .
 
 act:TransmissionShape
@@ -29,25 +30,21 @@ act:TransmissionShape
   ] ;
   sh:property [
     sh:path act:command-interface ;
-    sh:in (act:position act:velocity act:torque act:current) ;
+    sh:in (kc-stat:JointPosition kc-stat:JointVelocity kc-stat:JointForce act:current) ;
     sh:minCount 1 ;
-    sh:maxCount 1 ;
   ] ;
   sh:property [
     sh:path act:state-interface ;
-    sh:in (act:position act:velocity act:torque act:current) ;
+    sh:in (kc-stat:JointPosition kc-stat:JointVelocity kc-stat:JointForce act:current) ;
     sh:minCount 1 ;
   ] ;
   sh:sparql [
     sh:message "A transmission mechanical reduction must be nonzero." ;
     sh:select """
+      PREFIX act: <https://secorolab.github.io/metamodels/robot/actuation#>
       SELECT $this WHERE {
         $this act:mechanical-reduction ?value .
         FILTER (?value = 0.0)
       }
     """ ;
   ] .
-
-act:ActuatorShape
-  a sh:NodeShape ;
-  sh:targetClass act:Actuator .

--- a/robot/actuation.shacl.ttl
+++ b/robot/actuation.shacl.ttl
@@ -30,12 +30,12 @@ act:TransmissionShape
   ] ;
   sh:property [
     sh:path act:command-interface ;
-    sh:in (kc-stat:JointPosition kc-stat:JointVelocity kc-stat:JointForce act:current) ;
+    sh:in (kc-stat:JointPosition kc-stat:JointVelocity kc-stat:JointAcceleration kc-stat:JointForce act:current) ;
     sh:minCount 1 ;
   ] ;
   sh:property [
     sh:path act:state-interface ;
-    sh:in (kc-stat:JointPosition kc-stat:JointVelocity kc-stat:JointForce act:current) ;
+    sh:in (kc-stat:JointPosition kc-stat:JointVelocity kc-stat:JointAcceleration kc-stat:JointForce act:current) ;
     sh:minCount 1 ;
   ] ;
   sh:sparql [

--- a/robot/sensors.json
+++ b/robot/sensors.json
@@ -2,7 +2,6 @@
     "@context": {
         "@version": 1.1,
         "xsd": "http://www.w3.org/2001/XMLSchema#",
-        "qudt-quant": "http://qudt.org/vocab/quantitykind/",
         "sosa": "http://www.w3.org/ns/sosa/",
         "sens": "https://secorolab.github.io/metamodels/robot/sensors#",
 
@@ -16,7 +15,10 @@
         "observes": {
             "@id": "sosa:observes",
             "@type": "@id",
-            "@container": "@set"
+            "@container": "@set",
+            "@context": {
+                "@base": "http://qudt.org/vocab/quantitykind/"
+            }
         },
         "made-by-sensor": {
             "@id": "sosa:madeBySensor",
@@ -44,12 +46,7 @@
                     "@type": "xsd:integer"
                 },
                 "field-of-view": {
-                    "@id": "sens:field-of-view",
-                    "@type": "xsd:double"
-                },
-                "field-of-view-unit": {
-                    "@id": "sens:field-of-view-unit",
-                    "@type": "@id"
+                    "@id": "sens:field-of-view"
                 }
             }
         },
@@ -61,18 +58,9 @@
             "@type": "@id"
         },
         "update-rate": {
-            "@id": "sens:update-rate",
-            "@type": "xsd:double"
-        },
-        "update-rate-unit": {
-            "@id": "sens:update-rate-unit",
-            "@type": "@id"
+            "@id": "sens:update-rate"
         },
 
-        "force": "qudt-quant:Force",
-        "torque": "qudt-quant:Torque",
-        "angular-velocity": "qudt-quant:AngularVelocity",
-        "linear-acceleration": "qudt-quant:LinearAcceleration",
         "orientation": "sens:orientation",
         "image": "sens:image",
         "depth-image": "sens:depth-image"

--- a/robot/sensors.json
+++ b/robot/sensors.json
@@ -1,0 +1,80 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "xsd": "http://www.w3.org/2001/XMLSchema#",
+        "qudt-quant": "http://qudt.org/vocab/quantitykind/",
+        "sosa": "http://www.w3.org/ns/sosa/",
+        "sens": "https://secorolab.github.io/metamodels/robot/sensors#",
+
+        "Sensor": "sosa:Sensor",
+        "Platform": "sosa:Platform",
+        "hosts": {
+            "@id": "sosa:hosts",
+            "@type": "@id",
+            "@container": "@set"
+        },
+        "observes": {
+            "@id": "sosa:observes",
+            "@type": "@id",
+            "@container": "@set"
+        },
+        "made-by-sensor": {
+            "@id": "sosa:madeBySensor",
+            "@type": "@id"
+        },
+
+        "Camera": {
+            "@id": "sens:Camera",
+            "@context": {
+                "camera-kind": {
+                    "@id": "sens:camera-kind",
+                    "@type": "@vocab",
+                    "@context": {
+                        "rgb": "sens:rgb",
+                        "depth": "sens:depth",
+                        "rgbd": "sens:rgbd"
+                    }
+                },
+                "resolution-width": {
+                    "@id": "sens:resolution-width",
+                    "@type": "xsd:integer"
+                },
+                "resolution-height": {
+                    "@id": "sens:resolution-height",
+                    "@type": "xsd:integer"
+                },
+                "field-of-view": {
+                    "@id": "sens:field-of-view",
+                    "@type": "xsd:double"
+                },
+                "field-of-view-unit": {
+                    "@id": "sens:field-of-view-unit",
+                    "@type": "@id"
+                }
+            }
+        },
+        "ForceTorqueSensor": "sens:ForceTorqueSensor",
+        "IMU": "sens:IMU",
+
+        "frame": {
+            "@id": "sens:frame",
+            "@type": "@id"
+        },
+        "update-rate": {
+            "@id": "sens:update-rate",
+            "@type": "xsd:double"
+        },
+        "update-rate-unit": {
+            "@id": "sens:update-rate-unit",
+            "@type": "@id"
+        },
+
+        "force": "qudt-quant:Force",
+        "torque": "qudt-quant:Torque",
+        "angular-velocity": "qudt-quant:AngularVelocity",
+        "linear-acceleration": "qudt-quant:LinearAcceleration",
+        "orientation": "sens:orientation",
+        "image": "sens:image",
+        "depth-image": "sens:depth-image"
+    }
+}

--- a/robot/sensors.shacl.ttl
+++ b/robot/sensors.shacl.ttl
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: MPL-2.0
+# SPDX-FileCopyrightText: 2026 SECORO AG (secoro.uni-bremen.de)
+# Author: Vamsi Kalagaturu
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix geom: <https://comp-rob2b.github.io/metamodels/geometry/structural-entities#> .
+@prefix qudt-quant: <http://qudt.org/vocab/quantitykind/> .
+@prefix sosa: <http://www.w3.org/ns/sosa/> .
+@prefix sens: <https://secorolab.github.io/metamodels/robot/sensors#> .
+
+sens:PlatformShape
+  a sh:NodeShape ;
+  sh:targetClass sosa:Platform ;
+  sh:property [
+    sh:path sosa:hosts ;
+    sh:class sosa:Sensor ;
+  ] .
+
+sens:ObservationShape
+  a sh:NodeShape ;
+  sh:targetClass sosa:Observation ;
+  sh:property [
+    sh:path sosa:madeBySensor ;
+    sh:class sosa:Sensor ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+  ] .
+
+sens:CameraShape
+  a sh:NodeShape ;
+  sh:targetClass sens:Camera ;
+  sh:property [
+    sh:path rdf:type ;
+    sh:hasValue sosa:Sensor ;
+  ] ;
+  sh:property sens:FrameShape ;
+  sh:property sens:UpdateRateShape ;
+  sh:property sens:UpdateRateUnitShape ;
+  sh:property [
+    sh:path sens:camera-kind ;
+    sh:in (sens:rgb sens:depth sens:rgbd) ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+  ] ;
+  sh:property [
+    sh:path sens:resolution-width ;
+    sh:datatype xsd:integer ;
+    sh:minInclusive 1 ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+  ] ;
+  sh:property [
+    sh:path sens:resolution-height ;
+    sh:datatype xsd:integer ;
+    sh:minInclusive 1 ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+  ] ;
+  sh:property [
+    sh:path sens:field-of-view ;
+    sh:datatype xsd:double ;
+    sh:minExclusive 0.0 ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+  ] ;
+  sh:property [
+    sh:path sens:field-of-view-unit ;
+    sh:nodeKind sh:IRI ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+  ] .
+
+sens:ForceTorqueSensorShape
+  a sh:NodeShape ;
+  sh:targetClass sens:ForceTorqueSensor ;
+  sh:property [
+    sh:path rdf:type ;
+    sh:hasValue sosa:Sensor ;
+  ] ;
+  sh:property sens:FrameShape ;
+  sh:property sens:UpdateRateShape ;
+  sh:property sens:UpdateRateUnitShape ;
+  sh:property [
+    sh:path sosa:observes ;
+    sh:in (qudt-quant:Force qudt-quant:Torque) ;
+    sh:minCount 1 ;
+    sh:maxCount 2 ;
+  ] .
+
+sens:IMUShape
+  a sh:NodeShape ;
+  sh:targetClass sens:IMU ;
+  sh:property [
+    sh:path rdf:type ;
+    sh:hasValue sosa:Sensor ;
+  ] ;
+  sh:property sens:FrameShape ;
+  sh:property sens:UpdateRateShape ;
+  sh:property sens:UpdateRateUnitShape ;
+  sh:property [
+    sh:path sosa:observes ;
+    sh:in (
+      qudt-quant:AngularVelocity
+      qudt-quant:LinearAcceleration
+      sens:orientation
+    ) ;
+    sh:minCount 1 ;
+    sh:maxCount 3 ;
+  ] .
+
+sens:FrameShape
+  a sh:PropertyShape ;
+  sh:path sens:frame ;
+  sh:nodeKind sh:IRI ;
+  sh:class geom:Frame ;
+  sh:minCount 1 ;
+  sh:maxCount 1 .
+
+sens:UpdateRateShape
+  a sh:PropertyShape ;
+  sh:path sens:update-rate ;
+  sh:datatype xsd:double ;
+  sh:minExclusive 0.0 ;
+  sh:minCount 1 ;
+  sh:maxCount 1 .
+
+sens:UpdateRateUnitShape
+  a sh:PropertyShape ;
+  sh:path sens:update-rate-unit ;
+  sh:nodeKind sh:IRI ;
+  sh:minCount 1 ;
+  sh:maxCount 1 .

--- a/robot/sensors.shacl.ttl
+++ b/robot/sensors.shacl.ttl
@@ -5,6 +5,7 @@
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix geom: <https://comp-rob2b.github.io/metamodels/geometry/structural-entities#> .
+@prefix qudt: <http://qudt.org/schema/qudt/> .
 @prefix qudt-quant: <http://qudt.org/vocab/quantitykind/> .
 @prefix sosa: <http://www.w3.org/ns/sosa/> .
 @prefix sens: <https://secorolab.github.io/metamodels/robot/sensors#> .
@@ -36,7 +37,7 @@ sens:CameraShape
   ] ;
   sh:property sens:FrameShape ;
   sh:property sens:UpdateRateShape ;
-  sh:property sens:UpdateRateUnitShape ;
+  sh:property sens:FieldOfViewShape ;
   sh:property [
     sh:path sens:camera-kind ;
     sh:in (sens:rgb sens:depth sens:rgbd) ;
@@ -56,19 +57,6 @@ sens:CameraShape
     sh:minInclusive 1 ;
     sh:minCount 1 ;
     sh:maxCount 1 ;
-  ] ;
-  sh:property [
-    sh:path sens:field-of-view ;
-    sh:datatype xsd:double ;
-    sh:minExclusive 0.0 ;
-    sh:minCount 1 ;
-    sh:maxCount 1 ;
-  ] ;
-  sh:property [
-    sh:path sens:field-of-view-unit ;
-    sh:nodeKind sh:IRI ;
-    sh:minCount 1 ;
-    sh:maxCount 1 ;
   ] .
 
 sens:ForceTorqueSensorShape
@@ -80,7 +68,6 @@ sens:ForceTorqueSensorShape
   ] ;
   sh:property sens:FrameShape ;
   sh:property sens:UpdateRateShape ;
-  sh:property sens:UpdateRateUnitShape ;
   sh:property [
     sh:path sosa:observes ;
     sh:in (qudt-quant:Force qudt-quant:Torque) ;
@@ -97,7 +84,6 @@ sens:IMUShape
   ] ;
   sh:property sens:FrameShape ;
   sh:property sens:UpdateRateShape ;
-  sh:property sens:UpdateRateUnitShape ;
   sh:property [
     sh:path sosa:observes ;
     sh:in (
@@ -120,14 +106,59 @@ sens:FrameShape
 sens:UpdateRateShape
   a sh:PropertyShape ;
   sh:path sens:update-rate ;
-  sh:datatype xsd:double ;
-  sh:minExclusive 0.0 ;
+  sh:node sens:FrequencyQuantityShape ;
   sh:minCount 1 ;
   sh:maxCount 1 .
 
-sens:UpdateRateUnitShape
+sens:FieldOfViewShape
   a sh:PropertyShape ;
-  sh:path sens:update-rate-unit ;
-  sh:nodeKind sh:IRI ;
+  sh:path sens:field-of-view ;
+  sh:node sens:AngleQuantityShape ;
   sh:minCount 1 ;
   sh:maxCount 1 .
+
+sens:FrequencyQuantityShape
+  a sh:NodeShape ;
+  sh:class qudt:Quantity ;
+  sh:property [
+    sh:path qudt:hasQuantityKind ;
+    sh:hasValue qudt-quant:Frequency ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+  ] ;
+  sh:property [
+    sh:path qudt:unit ;
+    sh:nodeKind sh:IRI ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+  ] ;
+  sh:property [
+    sh:path qudt:value ;
+    sh:nodeKind sh:Literal ;
+    sh:minExclusive 0.0 ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+  ] .
+
+sens:AngleQuantityShape
+  a sh:NodeShape ;
+  sh:class qudt:Quantity ;
+  sh:property [
+    sh:path qudt:hasQuantityKind ;
+    sh:hasValue qudt-quant:Angle ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+  ] ;
+  sh:property [
+    sh:path qudt:unit ;
+    sh:nodeKind sh:IRI ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+  ] ;
+  sh:property [
+    sh:path qudt:value ;
+    sh:nodeKind sh:Literal ;
+    sh:minExclusive 0.0 ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+  ] .


### PR DESCRIPTION
## Summary

Adds the metamodel contexts and validation shapes needed by the robot model DSL work, while reusing existing QUDT and comp-rob2b terms wherever they already cover the concept:

- adds a Secoro kinematic-chain structural extension context for joint limits and **joint couplings** (mimic joints)
- models joint-limit bounds and coupling offsets as QUDT quantities instead of local scalar/unit pairs
- uses existing `kc-stat:JointPosition`, `kc-stat:JointVelocity`, `kc-stat:JointAcceleration`, and `kc-stat:JointForce` to classify joint limits
- grounds the mimic joint as a `JointCoupling`: a **scleronomic** (holonomic equality) constraint coupling two joint variables, following Featherstone's gear-constraint treatment (RBDA sec. 3.4, 9.6). `multiplier` is the gear ratio; `offset` is the affine term
- adds SHACL for joint limits, lower/upper ordering, unit/kind consistency, and type/kind consistency; and for joint couplings: required `Scleronomic` type, single independent/dependent joints, non-zero multiplier, self-coupling rejection, and independent/dependent joints sharing a position quantity kind
- adds a robot actuation context for transmissions, actuators, and the local electric-current interface term
- reuses existing `kc-stat:JointPosition`, `kc-stat:JointVelocity`, `kc-stat:JointAcceleration`, and `kc-stat:JointForce` (plus the local `act:current`) for transmission command/state interfaces
- adds a robot sensors context that reuses SOSA for sensors/platforms and QUDT quantity kinds for observed properties
- models sensor update rate and field of view as QUDT quantities

The comp-rob2b base contexts are not duplicated or overwritten; model data composes the base contexts and Secoro extension contexts explicitly.

## Extended and referenced concepts

The new contexts extend or reference these existing concept definitions:

- [`comp-rob2b/metamodels: qudt.json`](https://github.com/comp-rob2b/metamodels/blob/main/qudt.json): `Quantity`, `quantity-kind`, `unit`, and `value`
- [`comp-rob2b/metamodels: kinematic-chain/structural-entities.json`](https://github.com/comp-rob2b/metamodels/blob/main/kinematic-chain/structural-entities.json): base `Joint` and kinematic-chain structural terms
- [`comp-rob2b/metamodels: kinematic-chain/state.json`](https://github.com/comp-rob2b/metamodels/blob/main/kinematic-chain/state.json): joint position, velocity, acceleration, and force state terms
- [`W3C SOSA/SSN`](https://www.w3.org/TR/vocab-ssn/): `sosa:Sensor`, `sosa:Platform`, `sosa:hosts`, `sosa:observes`, and `sosa:madeBySensor`
- R. Featherstone, *Rigid Body Dynamics Algorithms*, Springer, 2008 — sec. 3.4 (constraint classification: holonomic / scleronomic) and sec. 9.6 (gears): the terminology grounding `Scleronomic` and the `JointCoupling` gear constraint

## Example model fragments

Joint limits compose the base kinematic-chain, state, QUDT, and Secoro extension contexts. The explicit limit category is the second `@type`; bounds are QUDT quantities.

```json
{
  "@context": [
    "https://comp-rob2b.github.io/metamodels/kinematic-chain/structural-entities.json",
    "https://comp-rob2b.github.io/metamodels/kinematic-chain/state.json",
    "https://comp-rob2b.github.io/metamodels/qudt.json",
    "https://secorolab.github.io/metamodels/kinematic-chain/structural-entities-extension.json",
    { "rob": "https://comp-rob2b.github.io/robots/kinova/gen3/7dof/" }
  ],
  "@id": "rob:joint1-position-limit",
  "@type": ["JointLimit", "JointPosition"],
  "of-joint": "rob:joint1",
  "lower": {
    "@type": "Quantity",
    "quantity-kind": "Angle",
    "value": -2.0,
    "unit": "RAD"
  },
  "upper": {
    "@type": "Quantity",
    "quantity-kind": "Angle",
    "value": 2.0,
    "unit": "RAD"
  }
}
```

A joint coupling (mimic joint) relates a `dependent-joint` to an `independent-joint` by `dependent = multiplier * independent + offset`. `Scleronomic` is stated as the second `@type`; `offset` is a QUDT quantity (same kind as the coupled joints' position); `multiplier` is a dimensionless ratio.

```json
{
  "@context": [
    "https://comp-rob2b.github.io/metamodels/kinematic-chain/structural-entities.json",
    "https://comp-rob2b.github.io/metamodels/qudt.json",
    "https://secorolab.github.io/metamodels/kinematic-chain/structural-entities-extension.json",
    { "rob": "https://comp-rob2b.github.io/robots/kinova/gen3/7dof/" }
  ],
  "@id": "rob:joint2-couples-joint1",
  "@type": ["JointCoupling", "Scleronomic"],
  "independent-joint": "rob:joint1",
  "dependent-joint": "rob:joint2",
  "multiplier": 1.0,
  "offset": {
    "@type": "Quantity",
    "quantity-kind": "Angle",
    "value": 0.0,
    "unit": "RAD"
  }
}
```

Actuation data reuses the kinematic-chain state terms for command/state interfaces (position, velocity, acceleration, force), plus the local `current` interface for current-controlled actuators.

```json
{
  "@context": [
    "https://comp-rob2b.github.io/metamodels/kinematic-chain/state.json",
    "https://secorolab.github.io/metamodels/robot/actuation.json",
    { "rob": "https://comp-rob2b.github.io/robots/kinova/gen3/7dof/" }
  ],
  "@id": "rob:joint1-transmission",
  "@type": "Transmission",
  "joint": "rob:joint1",
  "actuator": "rob:motor1",
  "gear-ratio": 1.0,
  "command-interface": ["JointForce"],
  "state-interface": ["JointPosition", "JointVelocity", "JointForce"]
}
```

Sensor data uses SOSA for sensor structure and QUDT quantities for numeric quantities with units.

```json
{
  "@context": [
    "https://comp-rob2b.github.io/metamodels/geometry/structural-entities.json",
    "https://comp-rob2b.github.io/metamodels/qudt.json",
    "https://secorolab.github.io/metamodels/robot/sensors.json",
    { "rob": "https://comp-rob2b.github.io/robots/kinova/gen3/7dof/" }
  ],
  "@graph": [
    {
      "@id": "rob:gen3",
      "@type": "Platform",
      "hosts": ["rob:wrist-camera", "rob:wrist-ft"]
    },
    {
      "@id": "rob:wrist-camera",
      "@type": ["Sensor", "Camera"],
      "frame": "rob:link0-joint1",
      "camera-kind": "depth",
      "resolution-width": 640,
      "resolution-height": 480,
      "field-of-view": {
        "@type": "Quantity",
        "quantity-kind": "Angle",
        "value": 70.0,
        "unit": "DEG"
      },
      "update-rate": {
        "@type": "Quantity",
        "quantity-kind": "Frequency",
        "value": 30.0,
        "unit": "HZ"
      }
    },
    {
      "@id": "rob:wrist-ft",
      "@type": ["Sensor", "ForceTorqueSensor"],
      "frame": "rob:link0-joint1",
      "observes": ["Force", "Torque"],
      "update-rate": {
        "@type": "Quantity",
        "quantity-kind": "Frequency",
        "value": 1000.0,
        "unit": "HZ"
      }
    }
  ]
}
```

## Validation

- parsed all modified JSON-LD context files and SHACL files with `rdflib.Graph.parse`
- ran `pyshacl.validate` checks for joint limits; joint couplings (valid coupling conforms; missing `Scleronomic` type, bare-double offset, zero multiplier, self-coupling, and mismatched independent/dependent quantity kinds are all rejected); actuation transmissions; and camera sensor quantities
- ran `git diff --check` on the modified files
