### PR TITLE
simplify actuation metamodel

### DIFF
--- a/robot/actuation.json
+++ b/robot/actuation.json
@@ -4,18 +4,14 @@
         "xsd": "http://www.w3.org/2001/XMLSchema#",
         "act": "https://secorolab.github.io/metamodels/robot/actuation#",
 
-        "Actuator": "act:Actuator",
-        "current": "act:current",
+        "JointCurrent": { "@id": "act:JointCurrent" },
+        "act-joint": { "@id": "act:joint", "@type": "@id" },
 
-        "Transmission": {
-            "@id": "act:Transmission",
+        "Actuation": {
+            "@id": "act:Actuation",
             "@context": {
                 "joint": {
                     "@id": "act:joint",
-                    "@type": "@id"
-                },
-                "actuator": {
-                    "@id": "act:actuator",
                     "@type": "@id"
                 },
                 "gear-ratio": {

--- a/robot/actuation.shacl.ttl
+++ b/robot/actuation.shacl.ttl
@@ -7,18 +7,12 @@
 @prefix kc-stat: <https://comp-rob2b.github.io/metamodels/kinematic-chain/state#> .
 @prefix act: <https://secorolab.github.io/metamodels/robot/actuation#> .
 
-act:TransmissionShape
+act:ActuationShape
   a sh:NodeShape ;
-  sh:targetClass act:Transmission ;
+  sh:targetClass act:Actuation ;
   sh:property [
     sh:path act:joint ;
     sh:class kc:Joint ;
-    sh:minCount 1 ;
-    sh:maxCount 1 ;
-  ] ;
-  sh:property [
-    sh:path act:actuator ;
-    sh:class act:Actuator ;
     sh:minCount 1 ;
     sh:maxCount 1 ;
   ] ;
@@ -30,12 +24,12 @@ act:TransmissionShape
   ] ;
   sh:property [
     sh:path act:command-interface ;
-    sh:in (kc-stat:JointPosition kc-stat:JointVelocity kc-stat:JointAcceleration kc-stat:JointForce act:current) ;
+    sh:in (kc-stat:JointPosition kc-stat:JointVelocity kc-stat:JointAcceleration kc-stat:JointForce act:JointCurrent) ;
     sh:minCount 1 ;
   ] ;
   sh:property [
     sh:path act:state-interface ;
-    sh:in (kc-stat:JointPosition kc-stat:JointVelocity kc-stat:JointAcceleration kc-stat:JointForce act:current) ;
+    sh:in (kc-stat:JointPosition kc-stat:JointVelocity kc-stat:JointAcceleration kc-stat:JointForce act:JointCurrent) ;
     sh:minCount 1 ;
   ] ;
   sh:sparql [


### PR DESCRIPTION
- Remove Transmission, since terminology seems to be only in automotive engineering. Instead Actuation will links to all configurations here.
- Add 'act-joint' outside of scoped context for compatibility with rdflib graph parsing.
- Rename 'current' to JointCurrent.
- Update SHACL constraint accordingly.