### PR TITLE
[robot/actuation] add mimic joint mm & shacl

### DIFF
--- a/robot/actuation.json
+++ b/robot/actuation.json
@@ -5,7 +5,21 @@
         "act": "https://secorolab.github.io/metamodels/robot/actuation#",
 
         "JointCurrent": { "@id": "act:JointCurrent" },
+
         "act-joint": { "@id": "act:joint", "@type": "@id" },
+        "act-mimic-joint": { "@id": "act:mimic-joint", "@type": "@id" },
+
+        "ScleronomousMimicConstraint": {
+            "@id": "act:ScleronomousMimicConstraint",
+            "@context": {
+                "joint": { "@id": "act:joint", "@type": "@id" },
+                "mimic": { "@id": "act:mimic-joint", "@type": "@id" },
+                "multiplier": { "@id": "act:multiplier", "@type": "xsd:double" },
+                "offset": { "@id": "act:offset", "@type": "xsd:double" }
+            }
+        },
+        "act-multiplier": { "@id": "act:multiplier", "@type": "xsd:double" },
+        "act-offset": { "@id": "act:offset", "@type": "xsd:double" },
 
         "Actuation": {
             "@id": "act:Actuation",

--- a/robot/actuation.shacl.ttl
+++ b/robot/actuation.shacl.ttl
@@ -7,15 +7,17 @@
 @prefix kc-stat: <https://comp-rob2b.github.io/metamodels/kinematic-chain/state#> .
 @prefix act: <https://secorolab.github.io/metamodels/robot/actuation#> .
 
+act:JointShape
+  a sh:PropertyShape ;
+  sh:path act:joint ;
+  sh:class kc:Joint ;
+  sh:minCount 1 ;
+  sh:maxCount 1 .
+
 act:ActuationShape
   a sh:NodeShape ;
   sh:targetClass act:Actuation ;
-  sh:property [
-    sh:path act:joint ;
-    sh:class kc:Joint ;
-    sh:minCount 1 ;
-    sh:maxCount 1 ;
-  ] ;
+  sh:property act:JointShape ;
   sh:property [
     sh:path act:gear-ratio ;
     sh:datatype xsd:double ;
@@ -41,4 +43,27 @@ act:ActuationShape
         FILTER (?value = 0.0)
       }
     """ ;
+  ] .
+
+act:ScleronomousMimicConstraintShape
+  a sh:NodeShape ;
+  sh:targetClass act:ScleronomousMimicConstraint ;
+  sh:property act:JointShape ;
+  sh:property [
+    sh:path act:mimic-joint ;
+    sh:class kc:Joint ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+  ] ;
+  sh:property [
+    sh:path act:multiplier ;
+    sh:datatype xsd:double ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+  ] ;
+  sh:property [
+    sh:path act:offset ;
+    sh:datatype xsd:double ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
   ] .


### PR DESCRIPTION
Add concepts to describe a [Scleronomous](https://en.wikipedia.org/wiki/Scleronomous) (time-independent) Constraint on 2 joints, which is the main type of mimic joint in various robot description formats. This is based on the classification in Featherstone's Rigid Body Dynamics book, under Fig. 3.1. Here, we just add offset & multiplier params, which is often the parameterization scheme in common standards.