### PR TITLE
Add SHACL shapes for prov (PROV-O)

### DIFF
--- a/prov.json
+++ b/prov.json
@@ -14,6 +14,17 @@
         "Activity": "prov:Activity",
         "Collection": "prov:Collection",
         "Bundle": "prov:Bundle",
+        "Plan": "prov:Plan",
+        "Role": "prov:Role",
+
+        "Usage": "prov:Usage",
+        "Generation": "prov:Generation",
+        "Invalidation": "prov:Invalidation",
+        "Communication": "prov:Communication",
+        "Association": "prov:Association",
+        "Attribution": "prov:Attribution",
+        "Delegation": "prov:Delegation",
+        "Derivation": "prov:Derivation",
 
         "wasGeneratedBy": {
             "@id": "prov:wasGeneratedBy",
@@ -91,6 +102,25 @@
         "hasVersion": {
             "@id": "dcterms:hasVersion",
             "@type": "xsd:string"
-        }
+        },
+
+        "qualifiedGeneration": { "@id": "prov:qualifiedGeneration", "@type": "@id" },
+        "qualifiedUsage": { "@id": "prov:qualifiedUsage", "@type": "@id" },
+        "qualifiedInvalidation": { "@id": "prov:qualifiedInvalidation", "@type": "@id" },
+        "qualifiedCommunication": { "@id": "prov:qualifiedCommunication", "@type": "@id" },
+        "qualifiedAssociation": { "@id": "prov:qualifiedAssociation", "@type": "@id" },
+        "qualifiedAttribution": { "@id": "prov:qualifiedAttribution", "@type": "@id" },
+        "qualifiedDelegation": { "@id": "prov:qualifiedDelegation", "@type": "@id" },
+        "qualifiedDerivation": { "@id": "prov:qualifiedDerivation", "@type": "@id" },
+
+        "entity": { "@id": "prov:entity", "@type": "@id" },
+        "activity": { "@id": "prov:activity", "@type": "@id" },
+        "agent": { "@id": "prov:agent", "@type": "@id" },
+        "hadRole": { "@id": "prov:hadRole", "@type": "@id" },
+        "hadPlan": { "@id": "prov:hadPlan", "@type": "@id" },
+        "hadActivity": { "@id": "prov:hadActivity", "@type": "@id" },
+        "hadGeneration": { "@id": "prov:hadGeneration", "@type": "@id" },
+        "hadUsage": { "@id": "prov:hadUsage", "@type": "@id" },
+        "atTime": { "@id": "prov:atTime", "@type": "xsd:dateTime" }
     }
 }

--- a/prov.shacl.ttl
+++ b/prov.shacl.ttl
@@ -1,0 +1,123 @@
+# SPDX-License-Identifier: MPL-2.0
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+prov:EntityShape
+  a sh:NodeShape ;
+  sh:targetClass prov:Entity ;
+  sh:nodeKind sh:IRI ;
+  sh:property [
+    sh:path prov:wasGeneratedBy ;
+    sh:class prov:Activity ;
+    sh:nodeKind sh:IRI
+  ] ;
+  sh:property [
+    sh:path prov:wasDerivedFrom ;
+    sh:class prov:Entity ;
+    sh:nodeKind sh:IRI
+  ] ;
+  sh:property [
+    sh:path prov:wasAttributedTo ;
+    sh:class prov:Agent ;
+    sh:nodeKind sh:IRI
+  ] ;
+  sh:property [
+    sh:path prov:generatedAtTime ;
+    sh:datatype xsd:dateTime ;
+    sh:maxCount 1
+  ] ;
+  sh:property [
+    sh:path prov:specializationOf ;
+    sh:class prov:Entity ;
+    sh:nodeKind sh:IRI
+  ] ;
+  sh:property [
+    sh:path prov:wasRevisionOf ;
+    sh:class prov:Entity ;
+    sh:nodeKind sh:IRI
+  ] ;
+  sh:property [
+    sh:path prov:wasInvalidatedBy ;
+    sh:class prov:Activity ;
+    sh:nodeKind sh:IRI
+  ] ;
+  sh:property [
+    sh:path prov:alternateOf ;
+    sh:class prov:Entity ;
+    sh:nodeKind sh:IRI
+  ] .
+
+prov:ActivityShape
+  a sh:NodeShape ;
+  sh:targetClass prov:Activity ;
+  sh:nodeKind sh:IRI ;
+  sh:property [
+    sh:path prov:used ;
+    sh:class prov:Entity ;
+    sh:nodeKind sh:IRI
+  ] ;
+  sh:property [
+    sh:path prov:wasInformedBy ;
+    sh:class prov:Activity ;
+    sh:nodeKind sh:IRI
+  ] ;
+  sh:property [
+    sh:path prov:wasAssociatedWith ;
+    sh:class prov:Agent ;
+    sh:nodeKind sh:IRI
+  ] ;
+  sh:property [
+    sh:path prov:startedAtTime ;
+    sh:datatype xsd:dateTime ;
+    sh:maxCount 1
+  ] ;
+  sh:property [
+    sh:path prov:endedAtTime ;
+    sh:datatype xsd:dateTime ;
+    sh:maxCount 1
+  ] .
+
+prov:AgentShape
+  a sh:NodeShape ;
+  sh:targetClass prov:Agent ;
+  sh:nodeKind sh:IRI ;
+  sh:property [
+    sh:path prov:actedOnBehalfOf ;
+    sh:class prov:Agent ;
+    sh:nodeKind sh:IRI
+  ] .
+
+prov:InfluenceSubjectShape
+  a sh:NodeShape ;
+  sh:targetSubjectsOf prov:wasInfluencedBy ;
+  sh:property [
+    sh:path prov:wasInfluencedBy ;
+    sh:nodeKind sh:IRI ;
+    sh:or (
+      [ sh:class prov:Entity ]
+      [ sh:class prov:Activity ]
+      [ sh:class prov:Agent ]
+    )
+  ] .
+
+prov:LocationSubjectShape
+  a sh:NodeShape ;
+  sh:targetSubjectsOf prov:atLocation ;
+  sh:property [
+    sh:path prov:atLocation ;
+    sh:nodeKind sh:IRI
+  ] .
+
+prov:CollectionShape
+  a sh:NodeShape ;
+  sh:targetClass prov:Collection ;
+  sh:property [
+    sh:path prov:hadMember ;
+    sh:class prov:Entity ;
+    sh:nodeKind sh:IRI
+  ] .
+
+prov:BundleShape
+  a sh:NodeShape ;
+  sh:targetClass prov:Bundle .

--- a/prov.shacl.ttl
+++ b/prov.shacl.ttl
@@ -46,6 +46,22 @@ prov:EntityShape
     sh:path prov:alternateOf ;
     sh:class prov:Entity ;
     sh:nodeKind sh:IRI
+  ] ;
+  sh:property [
+    sh:path prov:qualifiedGeneration ;
+    sh:class prov:Generation
+  ] ;
+  sh:property [
+    sh:path prov:qualifiedDerivation ;
+    sh:class prov:Derivation
+  ] ;
+  sh:property [
+    sh:path prov:qualifiedAttribution ;
+    sh:class prov:Attribution
+  ] ;
+  sh:property [
+    sh:path prov:qualifiedInvalidation ;
+    sh:class prov:Invalidation
   ] .
 
 prov:ActivityShape
@@ -76,6 +92,18 @@ prov:ActivityShape
     sh:path prov:endedAtTime ;
     sh:datatype xsd:dateTime ;
     sh:maxCount 1
+  ] ;
+  sh:property [
+    sh:path prov:qualifiedUsage ;
+    sh:class prov:Usage
+  ] ;
+  sh:property [
+    sh:path prov:qualifiedCommunication ;
+    sh:class prov:Communication
+  ] ;
+  sh:property [
+    sh:path prov:qualifiedAssociation ;
+    sh:class prov:Association
   ] .
 
 prov:AgentShape
@@ -86,6 +114,10 @@ prov:AgentShape
     sh:path prov:actedOnBehalfOf ;
     sh:class prov:Agent ;
     sh:nodeKind sh:IRI
+  ] ;
+  sh:property [
+    sh:path prov:qualifiedDelegation ;
+    sh:class prov:Delegation
   ] .
 
 prov:InfluenceSubjectShape
@@ -121,3 +153,158 @@ prov:CollectionShape
 prov:BundleShape
   a sh:NodeShape ;
   sh:targetClass prov:Bundle .
+
+# Qualified influences (PROV-O). Values may be blank nodes, so no sh:nodeKind
+# on the influence itself; the single-valued pointer to the influenced
+# entity/activity/agent is an IRI. prov:hadRole is left untyped (roles are
+# commonly plain IRIs, not asserted prov:Role instances).
+
+prov:UsageShape
+  a sh:NodeShape ;
+  sh:targetClass prov:Usage ;
+  sh:property [
+    sh:path prov:entity ;
+    sh:class prov:Entity ;
+    sh:nodeKind sh:IRI ;
+    sh:maxCount 1
+  ] ;
+  sh:property [
+    sh:path prov:atTime ;
+    sh:datatype xsd:dateTime ;
+    sh:maxCount 1
+  ] ;
+  sh:property [
+    sh:path prov:hadRole ;
+    sh:nodeKind sh:IRI
+  ] .
+
+prov:GenerationShape
+  a sh:NodeShape ;
+  sh:targetClass prov:Generation ;
+  sh:property [
+    sh:path prov:activity ;
+    sh:class prov:Activity ;
+    sh:nodeKind sh:IRI ;
+    sh:maxCount 1
+  ] ;
+  sh:property [
+    sh:path prov:atTime ;
+    sh:datatype xsd:dateTime ;
+    sh:maxCount 1
+  ] ;
+  sh:property [
+    sh:path prov:hadRole ;
+    sh:nodeKind sh:IRI
+  ] .
+
+prov:InvalidationShape
+  a sh:NodeShape ;
+  sh:targetClass prov:Invalidation ;
+  sh:property [
+    sh:path prov:activity ;
+    sh:class prov:Activity ;
+    sh:nodeKind sh:IRI ;
+    sh:maxCount 1
+  ] ;
+  sh:property [
+    sh:path prov:atTime ;
+    sh:datatype xsd:dateTime ;
+    sh:maxCount 1
+  ] ;
+  sh:property [
+    sh:path prov:hadRole ;
+    sh:nodeKind sh:IRI
+  ] .
+
+prov:CommunicationShape
+  a sh:NodeShape ;
+  sh:targetClass prov:Communication ;
+  sh:property [
+    sh:path prov:activity ;
+    sh:class prov:Activity ;
+    sh:nodeKind sh:IRI ;
+    sh:maxCount 1
+  ] ;
+  sh:property [
+    sh:path prov:hadRole ;
+    sh:nodeKind sh:IRI
+  ] .
+
+prov:AssociationShape
+  a sh:NodeShape ;
+  sh:targetClass prov:Association ;
+  sh:property [
+    sh:path prov:agent ;
+    sh:class prov:Agent ;
+    sh:nodeKind sh:IRI ;
+    sh:maxCount 1
+  ] ;
+  sh:property [
+    sh:path prov:hadPlan ;
+    sh:class prov:Plan ;
+    sh:nodeKind sh:IRI
+  ] ;
+  sh:property [
+    sh:path prov:hadRole ;
+    sh:nodeKind sh:IRI
+  ] .
+
+prov:AttributionShape
+  a sh:NodeShape ;
+  sh:targetClass prov:Attribution ;
+  sh:property [
+    sh:path prov:agent ;
+    sh:class prov:Agent ;
+    sh:nodeKind sh:IRI ;
+    sh:maxCount 1
+  ] ;
+  sh:property [
+    sh:path prov:hadRole ;
+    sh:nodeKind sh:IRI
+  ] .
+
+prov:DelegationShape
+  a sh:NodeShape ;
+  sh:targetClass prov:Delegation ;
+  sh:property [
+    sh:path prov:agent ;
+    sh:class prov:Agent ;
+    sh:nodeKind sh:IRI ;
+    sh:maxCount 1
+  ] ;
+  sh:property [
+    sh:path prov:hadRole ;
+    sh:nodeKind sh:IRI
+  ] .
+
+prov:DerivationShape
+  a sh:NodeShape ;
+  sh:targetClass prov:Derivation ;
+  sh:property [
+    sh:path prov:entity ;
+    sh:class prov:Entity ;
+    sh:nodeKind sh:IRI ;
+    sh:maxCount 1
+  ] ;
+  sh:property [
+    sh:path prov:hadActivity ;
+    sh:class prov:Activity ;
+    sh:nodeKind sh:IRI ;
+    sh:maxCount 1
+  ] ;
+  sh:property [
+    sh:path prov:hadGeneration ;
+    sh:class prov:Generation ;
+    sh:nodeKind sh:IRI ;
+    sh:maxCount 1
+  ] ;
+  sh:property [
+    sh:path prov:hadUsage ;
+    sh:class prov:Usage ;
+    sh:nodeKind sh:IRI ;
+    sh:maxCount 1
+  ] ;
+  sh:property [
+    sh:path prov:hadRole ;
+    sh:nodeKind sh:IRI
+  ] .


### PR DESCRIPTION
SHACL shapes for PROV-O (`prov.shacl.ttl`).

NodeShapes for `prov:Entity`, `prov:Activity`, `prov:Agent`, `prov:Collection` and `prov:Bundle`, and subject shapes for `prov:wasInfluencedBy` and `prov:atLocation`. Constrains the PROV-O relations (`wasGeneratedBy`, `used`, `wasAssociatedWith`, `wasDerivedFrom`, `generatedAtTime`, …) to their classes, IRI node kinds and cardinalities.