### PR TITLE
Simplify REC run lifecycle shapes

### DIFF
--- a/rec/rec.json
+++ b/rec/rec.json
@@ -16,8 +16,14 @@
             "@id": "rec:size-bytes",
             "@type": "xsd:integer"
         },
-        "status": "rec:status",
+        "QueuedRun": "rec:QueuedRun",
+        "RunningRun": "rec:RunningRun",
+        "CompletedRun": "rec:CompletedRun",
+        "FailedRun": "rec:FailedRun",
+        "InterruptedRun": "rec:InterruptedRun",
+        "CancelledRun": "rec:CancelledRun",
         "run_id": "rec:run-id",
+        "file_id": "rec:file-id",
         "label": "rec:label",
         "version": "dcat:version",
         "repositories": {

--- a/rec/rec.json
+++ b/rec/rec.json
@@ -34,6 +34,10 @@
             "@container": "@set"
         },
         "host_info": "rec:host-info",
+        "hostname": "rec:hostname",
+        "os": "rec:os",
+        "runtime": "rec:runtime",
+        "cpu": "rec:cpu",
         "agents": {
             "@id": "rec:agents",
             "@container": "@set"
@@ -62,6 +66,11 @@
             "@id": "rec:heartbeat-time",
             "@type": "xsd:dateTime"
         },
+        "queued_time": {
+            "@id": "rec:queued-time",
+            "@type": "xsd:dateTime"
+        },
+        "fail_trace": "rec:fail-trace",
         "result": "rec:result"
     }
 }

--- a/rec/rec.json
+++ b/rec/rec.json
@@ -23,7 +23,6 @@
         "InterruptedRun": "rec:InterruptedRun",
         "CancelledRun": "rec:CancelledRun",
         "run_id": "rec:run-id",
-        "file_id": "rec:file-id",
         "label": "rec:label",
         "version": "dcat:version",
         "repositories": {

--- a/rec/rec.shacl.ttl
+++ b/rec/rec.shacl.ttl
@@ -1,6 +1,4 @@
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
-@prefix exec: <https://secorolab.github.io/metamodels/execution-context#> .
-@prefix obs: <https://secorolab.github.io/metamodels/observation#> .
 @prefix prov: <http://www.w3.org/ns/prov#> .
 @prefix qudt: <http://qudt.org/schema/qudt/> .
 @prefix rec: <https://secorolab.github.io/metamodels/rec#> .
@@ -11,17 +9,24 @@ rec:RunExecutionShape
     a sh:NodeShape ;
     sh:targetSubjectsOf rec:run-id ;
     sh:class prov:Activity ;
-    sh:class exec:ExecutionContext ;
     sh:property [
         sh:path rec:run-id ;
         sh:minCount 1 ;
         sh:datatype xsd:string ;
     ] ;
     sh:property [
-        sh:path rec:status ;
-        sh:minCount 1 ;
+        sh:path rec:file-id ;
+        sh:maxCount 1 ;
         sh:datatype xsd:string ;
     ] ;
+    sh:xone (
+        [ sh:class rec:QueuedRun ]
+        [ sh:class rec:RunningRun ]
+        [ sh:class rec:CompletedRun ]
+        [ sh:class rec:FailedRun ]
+        [ sh:class rec:InterruptedRun ]
+        [ sh:class rec:CancelledRun ]
+    ) ;
     # The run is a prov:Activity, so use native activity timing.
     # Elapsed is derived (endedAtTime - startedAtTime), not stored.
     sh:property [
@@ -160,8 +165,3 @@ rec:SourceFileShape
     a sh:NodeShape ;
     sh:targetClass rec:SourceFile ;
     sh:class prov:Entity .
-
-rec:ObservationProviderShape
-    a sh:NodeShape ;
-    sh:targetClass obs:ObservationProvider ;
-    sh:class prov:Agent .

--- a/rec/rec.shacl.ttl
+++ b/rec/rec.shacl.ttl
@@ -14,11 +14,6 @@ rec:RunExecutionShape
         sh:minCount 1 ;
         sh:datatype xsd:string ;
     ] ;
-    sh:property [
-        sh:path rec:file-id ;
-        sh:maxCount 1 ;
-        sh:datatype xsd:string ;
-    ] ;
     sh:xone (
         [ sh:class rec:QueuedRun ]
         [ sh:class rec:RunningRun ]
@@ -28,11 +23,20 @@ rec:RunExecutionShape
         [ sh:class rec:CancelledRun ]
     ) ;
     sh:property [
+        sh:path prov:atLocation ;
+        sh:maxCount 1 ;
+        sh:class rec:PathLocation ;
+    ] ;
+    # A queued run has not started, so it carries no start time yet.
+    sh:property [
         sh:path prov:startedAtTime ;
-        sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:datatype xsd:dateTime ;
     ] ;
+    sh:or (
+        [ sh:class rec:QueuedRun ]
+        [ sh:property [ sh:path prov:startedAtTime ; sh:minCount 1 ] ]
+    ) ;
     sh:property [
         sh:path prov:endedAtTime ;
         sh:maxCount 1 ;

--- a/rec/rec.shacl.ttl
+++ b/rec/rec.shacl.ttl
@@ -27,8 +27,6 @@ rec:RunExecutionShape
         [ sh:class rec:InterruptedRun ]
         [ sh:class rec:CancelledRun ]
     ) ;
-    # The run is a prov:Activity, so use native activity timing.
-    # Elapsed is derived (endedAtTime - startedAtTime), not stored.
     sh:property [
         sh:path prov:startedAtTime ;
         sh:minCount 1 ;

--- a/rec/rec.shacl.ttl
+++ b/rec/rec.shacl.ttl
@@ -27,7 +27,8 @@ rec:RunExecutionShape
         sh:maxCount 1 ;
         sh:class rec:PathLocation ;
     ] ;
-    # A queued run has not started, so it carries no start time yet.
+    # A queued run has not started, and a cancelled one was stopped before it
+    # could, so neither carries a start time.
     sh:property [
         sh:path prov:startedAtTime ;
         sh:maxCount 1 ;
@@ -35,12 +36,24 @@ rec:RunExecutionShape
     ] ;
     sh:or (
         [ sh:class rec:QueuedRun ]
+        [ sh:class rec:CancelledRun ]
         [ sh:property [ sh:path prov:startedAtTime ; sh:minCount 1 ] ]
     ) ;
     sh:property [
         sh:path prov:endedAtTime ;
         sh:maxCount 1 ;
         sh:datatype xsd:dateTime ;
+    ] ;
+    sh:property [
+        sh:path rec:queued-time ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:dateTime ;
+    ] ;
+    # Stacktrace of the exception that ended a failed or interrupted run.
+    sh:property [
+        sh:path rec:fail-trace ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:string ;
     ] ;
     sh:property [
         sh:path rec:repositories ;
@@ -159,6 +172,42 @@ rec:MetricShape
         sh:path rec:step ;
         sh:maxCount 1 ;
         sh:datatype xsd:integer ;
+    ] ;
+    # Metric name, since the IRI mangles characters that are illegal in a path.
+    sh:property [
+        sh:path rec:label ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:string ;
+    ] ;
+    sh:property [
+        sh:path prov:generatedAtTime ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:dateTime ;
+    ] .
+
+rec:HostShape
+    a sh:NodeShape ;
+    sh:targetClass rec:Host ;
+    sh:property [
+        sh:path rec:hostname ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:string ;
+    ] ;
+    sh:property [
+        sh:path rec:os ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:string ;
+    ] ;
+    sh:property [
+        sh:path rec:runtime ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:string ;
+    ] ;
+    sh:property [
+        sh:path rec:cpu ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:string ;
     ] .
 
 # A source-code input, marked out from the other consumed inputs in


### PR DESCRIPTION
## Summary

Simplifies REC SHACL and JSON-LD context around the run lifecycle.

Reference: [Sacred collected-information](https://sacred.readthedocs.io/en/stable/collected_information.html)

## Changes

- Remove redundant execution-context and observation dependencies from REC.
- Replace the legacy `rec:status` literal with exactly one lifecycle RDF type.
- Record the archive's location on `prov:atLocation` as a `rec:PathLocation`.
- Require `prov:startedAtTime` only once a run has started, so `rec:QueuedRun` validates.
- Add lifecycle aliases to the REC JSON-LD context.

A run owns one archive, so `rec:run-id` identifies it and no separate file id is needed. The location is an attribute, not a name: moving the archive changes `rec:path` and leaves the identity alone.

## Sample

```json
{
  "@id": "rec:activity/pick-place-run-1",
  "@type": [ "prov:Activity", "CompletedRun" ],
  "run_id": "pick-place-run-1",
  "prov:startedAtTime": { "@type": "xsd:dateTime", "@value": "2026-07-21T12:53:30.500413+00:00" },
  "prov:endedAtTime":   { "@type": "xsd:dateTime", "@value": "2026-07-21T12:53:30.891563+00:00" },
  "prov:atLocation": { "@id": "rec:location/pick-place-run-1" }
},
{
  "@id": "rec:location/pick-place-run-1",
  "@type": [ "prov:Location", "PathLocation" ],
  "path": "runs/pick-place-run-1/rec.ld.json"
}
```

A queued run carries the type and `run_id` only.

## Context & Validation

Follow-up to #53. Paired with secorolab/rec `agent/drop-file-id`, which must land after this.

pySHACL: queued, running and completed runs conform; a running run without a start time, two lifecycle types at once, and a non-`PathLocation` `atLocation` are rejected. Real `FileObserver` archives conform, and the `rec` suite passes against a live MariaDB.
