### PR TITLE
Use OWL-Time instants for event loop and integrate FSM reactions

### DIFF
--- a/behaviour/event_loop.json
+++ b/behaviour/event_loop.json
@@ -1,9 +1,9 @@
 {
     "@context": {
-        "el": "https://secorolab.github.io/metamodels/behaviour/event_loop#",
+        "el": "https://secorolab.github.io/metamodels/behaviour/event-loop#",
         "EventLoop": { "@id": "el:EventLoop" },
+        "event-loop": { "@id": "el:event-loop", "@type": "@id" },
 
-        "Event": { "@id": "el:Event" },
         "has-event": { "@id": "el:has-event", "@type": "@id" },
         "ref-event": { "@id": "el:ref-event", "@type": "@id" },
 

--- a/behaviour/event_loop.shacl.ttl
+++ b/behaviour/event_loop.shacl.ttl
@@ -1,13 +1,14 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Author: Minh Nguyen (minh@mail.minhnh.com)
 @prefix sh: <http://www.w3.org/ns/shacl#> .
-@prefix el: <https://secorolab.github.io/metamodels/behaviour/event_loop#> .
+@prefix time: <http://www.w3.org/2006/time#> .
+@prefix el: <https://secorolab.github.io/metamodels/behaviour/event-loop#> .
 
 el:RefEventShape
   a sh:PropertyShape ;
-  sh:description ":ref-event must link to exactly 1 :Event" ;
+  sh:description ":ref-event must link to exactly 1 time:Instant" ;
   sh:path el:ref-event ;
-  sh:class el:Event ;
+  sh:class time:Instant ;
   sh:minCount 1 ;
   sh:maxCount 1 .
 
@@ -24,8 +25,8 @@ el:EventLoopShape
   sh:targetClass el:EventLoop ;
   sh:property [
     sh:path el:has-event ;
-    sh:class el:Event ;
-    sh:minCount 0 ;
+    sh:class time:Instant ;
+    sh:minCount 1 ;
   ] ;
   sh:property [
     sh:path el:has-flag ;

--- a/behaviour/fsm.json
+++ b/behaviour/fsm.json
@@ -1,9 +1,10 @@
 {
     "@context": {
         "fsm": "https://secorolab.github.io/metamodels/behaviour/fsm#",
+        "el": "https://secorolab.github.io/metamodels/behaviour/event-loop#",
         "xsd": "http://www.w3.org/2001/XMLSchema#",
 
-        "FSM": "fsm:FSM",
+        "FSM": "fsm:FiniteStateMachine",
 
         "name": { "@id": "fsm:name", "@type": "xsd:string" },
         "description": { "@id": "fsm:description", "@type": "xsd:string" },
@@ -22,20 +23,15 @@
                 }
             }
         },
-        "Reaction": { 
+        "Reaction": {
             "@id": "fsm:Reaction",
             "@context": {
                 "when-event": {
-                    "@id": "fsm:when-event",
+                    "@id": "el:ref-event",
                     "@type": "@id"
                 },
                 "do-transition": {
                     "@id": "fsm:do-transition",
-                    "@type": "@id"
-                },
-                "fires-events": {
-                    "@id": "fsm:fires-events",
-                    "@container": "@set",
                     "@type": "@id"
                 }
             }
@@ -49,11 +45,6 @@
         "start-state": { "@id": "fsm:start-state", "@type": "@id" },
         "current-state": { "@id": "fsm:current-state", "@type": "@id" },
         "end-state": { "@id": "fsm:end-state", "@type": "@id" },
-
-        "events": {
-            "@id": "fsm:events",
-            "@container": "@set"
-        },
 
         "transitions": {
             "@id": "fsm:transitions",

--- a/behaviour/fsm.json
+++ b/behaviour/fsm.json
@@ -33,6 +33,11 @@
                 "do-transition": {
                     "@id": "fsm:do-transition",
                     "@type": "@id"
+                },
+                "fires-events": {
+                    "@id": "fsm:fires-events",
+                    "@container": "@set",
+                    "@type": "@id"
                 }
             }
         },

--- a/behaviour/fsm.shacl.ttl
+++ b/behaviour/fsm.shacl.ttl
@@ -1,6 +1,7 @@
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix time: <http://www.w3.org/2006/time#> .
 @prefix fsm: <https://secorolab.github.io/metamodels/behaviour/fsm#> .
 @prefix el: <https://secorolab.github.io/metamodels/behaviour/event-loop#> .
 
@@ -103,4 +104,9 @@ fsm:ReactionShape
     sh:class fsm:Transition ;
     sh:minCount 1 ;
     sh:maxCount 1 ;
+  ] ;
+
+  sh:property [
+    sh:path fsm:fires-events ;
+    sh:class time:Instant ;
   ] .

--- a/behaviour/fsm.shacl.ttl
+++ b/behaviour/fsm.shacl.ttl
@@ -1,11 +1,12 @@
 @prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix fsm: <https://secorolab.github.io/metamodels/behaviour/fsm#> .
-@prefix el: <https://secorolab.github.io/metamodels/behaviour/event_loop#> .
+@prefix el: <https://secorolab.github.io/metamodels/behaviour/event-loop#> .
 
 fsm:FSMShape
   a sh:NodeShape ;
-  sh:targetClass fsm:FSM ;
+  sh:targetClass fsm:FiniteStateMachine ;
 
   sh:property [
     sh:path fsm:name ;
@@ -48,9 +49,10 @@ fsm:FSMShape
   ] ;
 
   sh:property [
-    sh:path fsm:events ;
-    sh:class el:Event ;
+    sh:path el:event-loop ;
+    sh:class el:EventLoop ;
     sh:minCount 1 ;
+    sh:maxCount 1 ;
   ] ;
 
   sh:property [
@@ -92,10 +94,8 @@ fsm:ReactionShape
   sh:targetClass fsm:Reaction ;
 
   sh:property [
-    sh:path fsm:when-event ;
-    sh:class el:Event ;
-    sh:minCount 1 ;
-    sh:maxCount 1 ;
+    sh:path rdf:type ;
+    sh:hasValue el:EventReaction ;
   ] ;
 
   sh:property [
@@ -103,9 +103,4 @@ fsm:ReactionShape
     sh:class fsm:Transition ;
     sh:minCount 1 ;
     sh:maxCount 1 ;
-  ] ;
-
-  sh:property [
-    sh:path fsm:fires-events ;
-    sh:class el:Event ;
   ] .


### PR DESCRIPTION
- replace event entities with time:Instant
- require event loops to contain at least one time instant
- link FSMs to an event loop instead of individual events
- require fsm:Reaction to also have type el:EventReaction
- map reaction events to el:ref-event
- update SHACL constraints for event references and transitions