### PR TITLE
Give SOSA/SSN a vocabulary file of its own

### DIFF
--- a/robot/sensors.json
+++ b/robot/sensors.json
@@ -2,28 +2,7 @@
     "@context": {
         "@version": 1.1,
         "xsd": "http://www.w3.org/2001/XMLSchema#",
-        "sosa": "http://www.w3.org/ns/sosa/",
         "sens": "https://secorolab.github.io/metamodels/robot/sensors#",
-
-        "Sensor": "sosa:Sensor",
-        "Platform": "sosa:Platform",
-        "hosts": {
-            "@id": "sosa:hosts",
-            "@type": "@id",
-            "@container": "@set"
-        },
-        "observes": {
-            "@id": "sosa:observes",
-            "@type": "@id",
-            "@container": "@set",
-            "@context": {
-                "@base": "http://qudt.org/vocab/quantitykind/"
-            }
-        },
-        "made-by-sensor": {
-            "@id": "sosa:madeBySensor",
-            "@type": "@id"
-        },
 
         "Camera": {
             "@id": "sens:Camera",

--- a/ssn.json
+++ b/ssn.json
@@ -1,0 +1,46 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "sosa": "http://www.w3.org/ns/sosa/",
+        "ssn": "http://www.w3.org/ns/ssn/",
+
+        "System": "ssn:System",
+        "Deployment": "ssn:Deployment",
+        "Platform": "sosa:Platform",
+        "Sensor": "sosa:Sensor",
+        "Actuator": "sosa:Actuator",
+        "Observation": "sosa:Observation",
+
+        "deployed-system": {
+            "@id": "ssn:deployedSystem",
+            "@type": "@id",
+            "@container": "@set"
+        },
+        "deployed-on-platform": {
+            "@id": "ssn:deployedOnPlatform",
+            "@type": "@id"
+        },
+        "has-sub-system": {
+            "@id": "ssn:hasSubSystem",
+            "@type": "@id",
+            "@container": "@set"
+        },
+        "hosts": {
+            "@id": "sosa:hosts",
+            "@type": "@id",
+            "@container": "@set"
+        },
+        "observes": {
+            "@id": "sosa:observes",
+            "@type": "@id",
+            "@container": "@set",
+            "@context": {
+                "@base": "http://qudt.org/vocab/quantitykind/"
+            }
+        },
+        "made-by-sensor": {
+            "@id": "sosa:madeBySensor",
+            "@type": "@id"
+        }
+    }
+}

--- a/ssn.shacl.ttl
+++ b/ssn.shacl.ttl
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: MPL-2.0
+# SPDX-FileCopyrightText: 2026 SECORO AG (secoro.uni-bremen.de)
+@prefix schema: <https://schema.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix sosa: <http://www.w3.org/ns/sosa/> .
+@prefix ssn: <http://www.w3.org/ns/ssn/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+# Shapes over W3C SOSA/SSN. No local classes: what equipment is (System, Platform,
+# Sensor) and what arranging it for a purpose is (Deployment) are both reused from the
+# standard. The shapes restate the spec's own domains and ranges, which RDFS only
+# entails -- a validator without a reasoner has to be told.
+
+ssn:Deployment
+    a sh:NodeShape ;
+    sh:targetClass ssn:Deployment ;
+    sh:message "A deployment deploys systems, on at most one platform." ;
+    sh:property [
+        sh:path ssn:deployedSystem ;
+        sh:nodeKind sh:IRI ;
+    ] ;
+    sh:property [
+        sh:path ssn:deployedOnPlatform ;
+        sh:nodeKind sh:IRI ;
+        sh:maxCount 1 ;
+    ] .
+
+ssn:System
+    a sh:NodeShape ;
+    sh:targetClass ssn:System ;
+    sh:message "A system is named once, and its parts are systems." ;
+    sh:property [
+        sh:path schema:name ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+    ] ;
+    sh:property [
+        sh:path ssn:hasSubSystem ;
+        sh:nodeKind sh:IRI ;
+        sh:class ssn:System ;
+    ] .
+
+# sosa:hosts is what mounting means, and its range is deliberately narrow: a platform
+# carries sensors, actuators, samplers and nested platforms, never a bare system. A
+# robot standing on a table is deployed there, not hosted by it.
+sosa:Platform
+    a sh:NodeShape ;
+    sh:targetClass sosa:Platform ;
+    sh:message "A platform hosts sensors, actuators or other platforms." ;
+    sh:property [
+        sh:path sosa:hosts ;
+        sh:nodeKind sh:IRI ;
+        sh:or (
+            [ sh:class sosa:Sensor ]
+            [ sh:class sosa:Actuator ]
+            [ sh:class sosa:Platform ]
+        ) ;
+    ] ;
+    sh:property [
+        sh:path schema:name ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+    ] .
+
+sosa:Sensor
+    a sh:NodeShape ;
+    sh:targetClass sosa:Sensor ;
+    sh:message "A sensor observes quantity kinds." ;
+    sh:property [
+        sh:path sosa:observes ;
+        sh:nodeKind sh:IRI ;
+    ] .


### PR DESCRIPTION
`sosa:Sensor`, `sosa:Platform` and `sosa:hosts` were declared inside `robot/sensors.json` — an external W3C vocabulary defined in a file named for one of the things that borrows it.

- **`ssn.json`** (new) — the SOSA/SSN context. Covers `System`, `Deployment`, `Platform`, `Sensor`, `Actuator`, `Observation`, and `deployed-system`, `deployed-on-platform`, `has-sub-system`, `hosts`, `observes`, `made-by-sensor`.
- **`ssn.shacl.ttl`** (new) — restates the domains and ranges the spec only entails, since a validator has no reasoner. Notably the narrow range of `sosa:hosts`: sensors, actuators and nested platforms, never a bare `ssn:System`.
- **`robot/sensors.json`** — keeps only its own `sens:` terms.

Terms from [SSN §Systems and their Deployment](https://www.w3.org/TR/vocab-ssn/#Systems-and-their-Deployment). W3C publishes SSN/SOSA only as Turtle, RDF/XML and HTML, so the context is hand-written, following `time.json` and `prov.json`.

**Compatibility:** anything importing `robot/sensors.json` for `Sensor`/`Platform`/`hosts` now also needs `ssn.json`. Nothing in the workspace does — scene-dsl builds those IRIs from Python constants.