### PR TITLE
Add a wrench built from a direction and a moment

### DIFF
--- a/newtonian-rigid-body-dynamics/operators-extension.json
+++ b/newtonian-rigid-body-dynamics/operators-extension.json
@@ -1,0 +1,16 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "dyn-op": "https://comp-rob2b.github.io/metamodels/newtonian-rigid-body-dynamics/operators#",
+        "dyn-op-ext": "https://secorolab.github.io/metamodels/newtonian-rigid-body-dynamics/operators#",
+
+        "WrenchFromDirectionAndMoment": {
+            "@id": "dyn-op-ext:WrenchFromDirectionAndMoment",
+            "@context": {
+                "moment": { "@id": "dyn-op-ext:moment", "@type": "@id" },
+                "direction": { "@id": "dyn-op:direction", "@type": "@id" },
+                "wrench": { "@id": "dyn-op:wrench", "@type": "@id" }
+            }
+        }
+    }
+}

--- a/newtonian-rigid-body-dynamics/operators-extension.shacl.ttl
+++ b/newtonian-rigid-body-dynamics/operators-extension.shacl.ttl
@@ -1,0 +1,33 @@
+@prefix dyn-op:      <https://comp-rob2b.github.io/metamodels/newtonian-rigid-body-dynamics/operators#> .
+@prefix dyn-op-ext:  <https://secorolab.github.io/metamodels/newtonian-rigid-body-dynamics/operators#> .
+@prefix dyn-coord:   <https://comp-rob2b.github.io/metamodels/newtonian-rigid-body-dynamics/coordinates#> .
+@prefix geom-coord:  <https://comp-rob2b.github.io/metamodels/geometry/coordinates#> .
+@prefix qudt:        <http://qudt.org/schema/qudt/> .
+@prefix rdfs:        <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh:          <http://www.w3.org/ns/shacl#> .
+
+dyn-op-ext:WrenchFromDirectionAndMoment
+    a rdfs:Class, sh:NodeShape ;
+    sh:targetClass dyn-op-ext:WrenchFromDirectionAndMoment ;
+    sh:message "A moment command needs one magnitude, one direction and one wrench coordinate; it is a couple, so it carries no reference position." ;
+    sh:property [
+        sh:path dyn-op-ext:moment ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:class qudt:Quantity
+    ] ;
+    sh:property [
+        sh:path dyn-op:direction ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:class geom-coord:DirectionCoordinate
+    ] ;
+    sh:property [
+        sh:path dyn-op:wrench ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:class dyn-coord:WrenchCoordinate
+    ] .


### PR DESCRIPTION
comp-rob2b's `dyn-op:WrenchFromPositionDirectionAndMagnitude` is the only operator that builds a commanded wrench, and it puts the magnitude in the force slot with a zero moment. So a commanded wrench could only ever be a force — an angular constraint had no way to command a moment.

`dyn-op-ext:WrenchFromDirectionAndMoment` fills the moment slot instead:

    moment    -> qudt:Quantity              (Torque, N-M)
    direction -> geom-coord:DirectionCoordinate
    wrench    -> dyn-coord:WrenchCoordinate

A couple is reference-point independent, so it carries no `position` — that is the one semantic difference from the comp-rob2b operator. Predicates are reused from `dyn-op:` except `moment`.

New namespace `dyn-op-ext:` for `newtonian-rigid-body-dynamics/operators#`, mirroring the existing `geometry/spatial-operators-extension`, with the JSON-LD context sibling.

Consumed by motion-spec-dsl to give an orientation constraint an impedance that acts through `f_ext`. That side is on `dev` in motion-spec-dsl and motion-spec and lists this file in every generated manifest, so `motion-spec check` needs this merged.