### PR TITLE
Add a subtraction op to the algorithm extension

### DIFF
--- a/algorithm-extension.json
+++ b/algorithm-extension.json
@@ -24,6 +24,15 @@
             }
         },
 
+        "Subtraction": {
+            "@id": "algo-ext:Subtraction",
+            "@context": {
+                "minuend": { "@id": "algo-ext:minuend", "@type": "@id" },
+                "subtrahend": { "@id": "algo-ext:subtrahend", "@type": "@id" },
+                "out": { "@id": "algo-ext:out", "@type": "@id" }
+            }
+        },
+
         "VelocityProfile": {
             "@id": "algo-ext:VelocityProfile",
             "@context": {

--- a/algorithm-extension.shacl.ttl
+++ b/algorithm-extension.shacl.ttl
@@ -37,6 +37,16 @@ algo-ext:Addition
     sh:property [ sh:path algo-ext:in ; sh:minCount 2 ; sh:nodeKind sh:BlankNodeOrIRI ; sh:class qudt:Quantity ] ;
     sh:property [ sh:path algo-ext:out ; sh:minCount 1 ; sh:maxCount 1 ; sh:nodeKind sh:BlankNodeOrIRI ; sh:class qudt:Quantity ] .
 
+# Subtraction is neither commutative nor associative, so its operands are named rather than
+# collected: the subtrahend is taken from the minuend, and exactly one of each says which.
+algo-ext:Subtraction
+    a rdfs:Class, sh:NodeShape ;
+    sh:targetClass algo-ext:Subtraction ;
+    sh:message "A subtraction needs one quantity to take from, one to take, and one quantity output." ;
+    sh:property [ sh:path algo-ext:minuend ; sh:minCount 1 ; sh:maxCount 1 ; sh:nodeKind sh:BlankNodeOrIRI ; sh:class qudt:Quantity ] ;
+    sh:property [ sh:path algo-ext:subtrahend ; sh:minCount 1 ; sh:maxCount 1 ; sh:nodeKind sh:BlankNodeOrIRI ; sh:class qudt:Quantity ] ;
+    sh:property [ sh:path algo-ext:out ; sh:minCount 1 ; sh:maxCount 1 ; sh:nodeKind sh:BlankNodeOrIRI ; sh:class qudt:Quantity ] .
+
 # Profiled approach to a target: rate-limited by velocity, acceleration and (for an
 # s-curve) jerk, it emits the setpoint the controller tracks and re-emits it every
 # cycle until the target is reached.


### PR DESCRIPTION
`algo-ext:Addition` collects its addends under one predicate because their order does not change what the op means. Subtraction's does, so `algo-ext:Subtraction` names its operands instead: exactly one `minuend` to take from, one `subtrahend` to take, one `out`.

This is what a motion-spec context declaration needs to state `= snapshot of <x> - <offset>`; until now a model that wanted the offset taken off had to declare a second quantity holding the negative of the first.

Both files carry it: the SHACL shape and the JSON-LD context entry.