### PR TITLE
algorithm-extension: multiplication and division

### DIFF
--- a/algorithm-extension.json
+++ b/algorithm-extension.json
@@ -33,6 +33,23 @@
             }
         },
 
+        "Multiplication": {
+            "@id": "algo-ext:Multiplication",
+            "@context": {
+                "in": { "@id": "algo-ext:in", "@type": "@id", "@container": "@set" },
+                "out": { "@id": "algo-ext:out", "@type": "@id" }
+            }
+        },
+
+        "Division": {
+            "@id": "algo-ext:Division",
+            "@context": {
+                "dividend": { "@id": "algo-ext:dividend", "@type": "@id" },
+                "divisor": { "@id": "algo-ext:divisor", "@type": "@id" },
+                "out": { "@id": "algo-ext:out", "@type": "@id" }
+            }
+        },
+
         "VelocityProfile": {
             "@id": "algo-ext:VelocityProfile",
             "@context": {

--- a/algorithm-extension.shacl.ttl
+++ b/algorithm-extension.shacl.ttl
@@ -47,6 +47,24 @@ algo-ext:Subtraction
     sh:property [ sh:path algo-ext:subtrahend ; sh:minCount 1 ; sh:maxCount 1 ; sh:nodeKind sh:BlankNodeOrIRI ; sh:class qudt:Quantity ] ;
     sh:property [ sh:path algo-ext:out ; sh:minCount 1 ; sh:maxCount 1 ; sh:nodeKind sh:BlankNodeOrIRI ; sh:class qudt:Quantity ] .
 
+# Multiplication is commutative and associative, so the factors are an unordered set.
+algo-ext:Multiplication
+    a rdfs:Class, sh:NodeShape ;
+    sh:targetClass algo-ext:Multiplication ;
+    sh:message "A multiplication needs two or more quantity inputs and one quantity output." ;
+    sh:property [ sh:path algo-ext:in ; sh:minCount 2 ; sh:nodeKind sh:BlankNodeOrIRI ; sh:class qudt:Quantity ] ;
+    sh:property [ sh:path algo-ext:out ; sh:minCount 1 ; sh:maxCount 1 ; sh:nodeKind sh:BlankNodeOrIRI ; sh:class qudt:Quantity ] .
+
+# Division is neither commutative nor associative, so its operands are named rather than
+# collected: the dividend is divided by the divisor, and exactly one of each says which.
+algo-ext:Division
+    a rdfs:Class, sh:NodeShape ;
+    sh:targetClass algo-ext:Division ;
+    sh:message "A division needs one quantity to divide, one to divide by, and one quantity output." ;
+    sh:property [ sh:path algo-ext:dividend ; sh:minCount 1 ; sh:maxCount 1 ; sh:nodeKind sh:BlankNodeOrIRI ; sh:class qudt:Quantity ] ;
+    sh:property [ sh:path algo-ext:divisor ; sh:minCount 1 ; sh:maxCount 1 ; sh:nodeKind sh:BlankNodeOrIRI ; sh:class qudt:Quantity ] ;
+    sh:property [ sh:path algo-ext:out ; sh:minCount 1 ; sh:maxCount 1 ; sh:nodeKind sh:BlankNodeOrIRI ; sh:class qudt:Quantity ] .
+
 # Profiled approach to a target: rate-limited by velocity, acceleration and (for an
 # s-curve) jerk, it emits the setpoint the controller tracks and re-emits it every
 # cycle until the target is reached.


### PR DESCRIPTION
Addition and Subtraction were the only arithmetic the extension named, so a model could add two quantities but not scale one by another.

- `algo-ext:Multiplication` mirrors `Addition`: commutative and associative, so its factors collect under `algo-ext:in` as an unordered set (`sh:minCount 2`).
- `algo-ext:Division` mirrors `Subtraction`: order matters, so the operands are named `algo-ext:dividend` and `algo-ext:divisor` rather than collected.

Both are added to the JSON-LD context and given matching SHACL node shapes.

Needed by motion-spec-dsl `dc30a2e`, which lets a model write `*` and `/` between quantities and lowers them to these two classes, and motion-spec `81f76ea`, which registers and renders them.