### PR TITLE
Add RotationVectorFromDirections to the spatial operators extension

### DIFF
--- a/geometry/spatial-operators-extension.json
+++ b/geometry/spatial-operators-extension.json
@@ -29,6 +29,15 @@
             }
         },
 
+        "RotationVectorFromDirections": {
+            "@id": "geom-op-ext:RotationVectorFromDirections",
+            "@context": {
+                "in1": { "@id": "geom-op:in1", "@type": "@id" },
+                "in2": { "@id": "geom-op:in2", "@type": "@id" },
+                "out": { "@id": "geom-op:out", "@type": "@id" }
+            }
+        },
+
         "ComposeOrientation": {
             "@id": "geom-op-ext:ComposeOrientation",
             "@context": {

--- a/geometry/spatial-operators-extension.shacl.ttl
+++ b/geometry/spatial-operators-extension.shacl.ttl
@@ -71,6 +71,32 @@ geom-op-ext:PoseToAngularDistance
         sh:class geom-coord:AngularDistanceCoordinate
     ] .
 
+geom-op-ext:RotationVectorFromDirections
+    a rdfs:Class, sh:NodeShape ;
+    sh:targetClass geom-op-ext:RotationVectorFromDirections ;
+    sh:message "A rotation-vector-from-directions op needs two direction-coordinate inputs and one vector output." ;
+    sh:property [
+        sh:path geom-op:in1 ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:class geom-coord:DirectionCoordinate
+    ] ;
+    sh:property [
+        sh:path geom-op:in2 ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:class geom-coord:DirectionCoordinate
+    ] ;
+    sh:property [
+        sh:path geom-op:out ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:class geom-coord:VectorXYZ
+    ] .
+
 geom-op-ext:ComposeOrientation
     a rdfs:Class, sh:NodeShape ;
     sh:targetClass geom-op-ext:ComposeOrientation ;


### PR DESCRIPTION
The rotation carrying one direction onto another, as an axis-angle vector in the frame both are seen by.

`in1` is the moving direction, already rotated into the reference frame; `in2` is the direction it should line up with. Here: keep the forearm's own up axis pointing along the base z.

```json
{ "@id": "forearm-up", "@type": "DirectionCoordinate",
  "as-seen-by": "kinova/forearm_link", "x": 0, "y": 1, "z": 0 },

{ "@id": "base-up", "@type": "DirectionCoordinate",
  "as-seen-by": "kinova/base_link", "x": 0, "y": 0, "z": 1 },

{ "@type": "RotateDirectionDistalToProximalWithPose",
  "pose": "pose-forearm-base", "from": "forearm-up", "to": "forearm-up-rotated" },

{ "@type": "RotationVectorFromDirections",
  "in1": "forearm-up-rotated", "in2": "base-up", "out": "align-error" }
```

`out = (in1 x in2) * theta/sin(theta)`, with `theta = atan2(|in1 x in2|, in1 . in2)`.

With `in2` a frame axis, `out`'s component along it is identically zero and the other two are the signed angle errors about the frame's remaining axes — one per solver row. The free spin about the aligned axis is that zero.