### PR TITLE
Complete the core behaviour-tree vocabulary

### DIFF
--- a/behaviour/behaviour-tree.json
+++ b/behaviour/behaviour-tree.json
@@ -16,20 +16,13 @@
         "Selector": { "@id": "bt:Selector" },
         "Parallel": { "@id": "bt:Parallel" },
 
-        "has-child": { "@id": "bt:has-child", "@type": "@id" },
+        "memory": { "@id": "bt:memory", "@type": "xsd:boolean" },
+        "success-threshold": { "@id": "bt:success-threshold", "@type": "xsd:positiveInteger" },
 
-        "ActionSubtree": { "@id": "bt:ActionSubtree" },
-        "of-subtree": { "@id": "bt:of-subtree", "@type": "@id" },
-        "parent": { "@id": "bt:parent", "@type": "@id" },
-        "subroot": { "@id": "bt:subroot", "@type": "@id" },
+        "children": { "@id": "bt:children", "@container": "@list", "@type": "@id" },
 
+        "BehaviourTree": { "@id": "bt:BehaviourTree" },
         "BehaviourTreeWithEvents": { "@id": "bt:BehaviourTreeWithEvents" },
-        "root": { "@id": "bt:root", "@type": "@id" },
-
-        "SubtreeImpl": { "@id": "bt:SubtreeImpl" },
-
-        "PythonActionImpl": { "@id": "bt:PythonActionImpl" },
-
-        "uses-impl": { "@id": "bt:uses-implementation", "@type": "@id" }
+        "root": { "@id": "bt:root", "@type": "@id" }
     }
 }

--- a/behaviour/behaviour-tree.shacl.ttl
+++ b/behaviour/behaviour-tree.shacl.ttl
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix bt: <https://secorolab.github.io/metamodels/behaviour/behaviour-tree#> .
+
+bt:MemoryShape
+  a sh:PropertyShape ;
+  sh:description ":memory says whether the composite re-ticks children that already finished" ;
+  sh:path bt:memory ;
+  sh:datatype xsd:boolean ;
+  sh:minCount 1 ;
+  sh:maxCount 1 .
+
+bt:NoChildShape
+  a sh:PropertyShape ;
+  sh:description "a leaf has no children in the tree it sits in" ;
+  sh:path bt:children ;
+  sh:maxCount 0 .
+
+bt:BehaviourTreeShape
+  a sh:NodeShape ;
+  sh:targetClass bt:BehaviourTree ;
+
+  sh:property [
+    sh:path bt:root ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+  ] .
+
+bt:CompositeShape
+  a sh:NodeShape ;
+  sh:description "a control flow node has one ordered, non-empty list of children" ;
+  sh:targetClass bt:Sequence, bt:Selector, bt:Parallel ;
+
+  sh:property [
+    sh:path bt:children ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+  ] ;
+
+  sh:property [
+    sh:description "sibling order is semantics, so the list order is the tick order" ;
+    sh:path ( bt:children [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ;
+    sh:minCount 1 ;
+  ] .
+
+bt:SequenceShape
+  a sh:NodeShape ;
+  sh:targetClass bt:Sequence ;
+  sh:property bt:MemoryShape .
+
+bt:SelectorShape
+  a sh:NodeShape ;
+  sh:targetClass bt:Selector ;
+  sh:property bt:MemoryShape .
+
+bt:ParallelShape
+  a sh:NodeShape ;
+  sh:targetClass bt:Parallel ;
+
+  sh:property [
+    sh:description ":success-threshold is the M of N children that must succeed" ;
+    sh:path bt:success-threshold ;
+    sh:datatype xsd:positiveInteger ;
+    sh:minInclusive 1 ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+  ] .
+
+bt:ActionShape
+  a sh:NodeShape ;
+  sh:targetClass bt:Action ;
+  sh:property bt:NoChildShape ;
+
+  sh:property [
+    sh:path bt:of-action ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+  ] .
+
+bt:ConditionShape
+  a sh:NodeShape ;
+  sh:targetClass bt:Condition ;
+  sh:property bt:NoChildShape .


### PR DESCRIPTION
`behaviour/behaviour-tree.json` could not express a behaviour tree unambiguously.
Checked against Colledanchise & Ögren, *Behavior Trees in Robotics and AI*,
§1.3 "Classical Formulation of BTs".

## What was missing

| concept | before |
|---|---|
| memory | absent — `Sequence`/`Selector` could not say whether they re-tick finished children |
| Parallel threshold | absent — "any child succeeds" and "all children succeed" were the same term |
| child order | `has-child` is unordered, but a BT routes ticks "to its children from the left" (§1.3) |
| plain tree | only `BehaviourTreeWithEvents` existed |

## Added

```
bt:memory              xsd:boolean           on Sequence / Selector
bt:success-threshold   xsd:positiveInteger   on Parallel — the M of N
bt:BehaviourTree                             class
```

`bt:success-threshold` is the book's M: "returns Success if M children return
Success, it returns Failure if N − M + 1 children return Failure … M ≤ N is a
user defined threshold".

## Changed — `bt:has-child` → `bt:children`, an `@list`

```json
"children": { "@id": "bt:children", "@container": "@list", "@type": "@id" }
```

Order is BT semantics, not annotation, so it belongs in the term rather than in a
separate index property that every reader would have to sort by. `floorplan:spaces`
already orders its members this way. A tree then reads as a tree:

```turtle
ex:pick-root a bt:Sequence ;
    bt:children ( ex:approach_object ex:pick-root-1 ex:pick-root-2 ) ;
    bt:memory true .
```

## Removed

```
bt:ActionSubtree        a tree is itself a child
bt:of-subtree           ditto
bt:parent               inverse of bt:children
bt:subroot              the child tree's bt:root
bt:SubtreeImpl          implementation binding
bt:PythonActionImpl     implementation binding
bt:uses-implementation  implementation binding
```

**Subtrees.** §2.2 says a subtree "can be seen as a module of its own, with the
same interface as an atomic action" — it substitutes for *any* node. So a
`bt:BehaviourTree` sits in the child list as itself and the reader ticks its
`bt:root`; no wrapper node, no predicate:

```turtle
ex:approach_object a bt:BehaviourTree ;
    bt:root ex:approach_object-root .
```

A wrapper would only earn its place once a call site carries data of its own —
a label, BT.CPP-style port remapping — which nothing here does. The only position
a subtree can't take is a Condition's, since "a Condition node never returns a
status of Running" (§1.3) and a subtree can.

**Derivable.** `parent` is the inverse of `children`; `subroot` is the child
tree's `root`.

**Implementation binding** is target-specific and not core. A `Condition` names
what it checks by composing with the event-loop metamodel, so it needs no term
here:

```turtle
ex:object_visible a el:Flag .
ex:pick-root-0 a bt:Condition ;
    el:ref-flag ex:object_visible .
```

## Shapes

`behaviour/behaviour-tree.shacl.ttl` is new; `fsm` and `event_loop` both already
have one. It checks arity — composites have "at least one child" per §1.3, leaves
have none, a tree has one root — and value ranges. The three composites share a
single shape with `sh:targetClass bt:Sequence, bt:Selector, bt:Parallel`, since
their child-list constraints are identical. Members are reached with

```turtle
sh:path ( bt:children [ sh:zeroOrMorePath rdf:rest ] rdf:first )
```

Checked that each shape rejects what it claims to — empty list, two lists, no
`bt:children`, missing `bt:memory`, a leaf with children, threshold `0`, and a
tree with no root all fail; a composite holding a tree as its child passes.

## Breaking

Readers of `bt:has-child`, `bt:ActionSubtree`, `bt:of-subtree`, `bt:parent`,
`bt:subroot` or `bt:uses-implementation` need updating. `bdd-dsl`'s BT query is
the one consumer I know of.

Worth noting for future shapes: `sh:datatype xsd:positiveInteger` alone does not
reject `0`. pyshacl compares the datatype IRI, not the literal's value space, so
`"0"^^xsd:positiveInteger` validated clean until an explicit `sh:minInclusive`
was added.
