### PR TITLE
Geometric constraint expressions: line and plane primitives, Table II relations and operators

### DIFF
--- a/algorithm-extension.json
+++ b/algorithm-extension.json
@@ -79,23 +79,6 @@
                 "damping": { "@id": "algo-ext:damping", "@type": "@id" },
                 "stiffness": { "@id": "algo-ext:stiffness", "@type": "@id" }
             }
-        },
-
-        "Snapshot": {
-            "@id": "algo-ext:Snapshot",
-            "@context": {
-                "in": { "@id": "algo-ext:in", "@type": "@id" },
-                "out": { "@id": "algo-ext:out", "@type": "@id" },
-                "sampling": {
-                    "@id": "algo-ext:sampling",
-                    "@type": "@vocab",
-                    "@context": {
-                        "initial-sampling": "algo-ext:initial-sampling",
-                        "event-triggered-sampling": "algo-ext:event-triggered-sampling"
-                    }
-                },
-                "trigger": { "@id": "algo-ext:trigger", "@type": "@id" }
-            }
         }
     }
 }

--- a/algorithm-extension.shacl.ttl
+++ b/algorithm-extension.shacl.ttl
@@ -118,26 +118,6 @@ algo-ext:PositiveLinearJerkShape
     sh:property [ sh:path qudt:hasQuantityKind ; sh:hasValue qkind-ext:LinearJerk ] ;
     sh:node algo-ext:PositiveValueShape .
 
-# Sample-and-hold: captures its input once, or again on every trigger, and holds it.
-algo-ext:Snapshot
-    a rdfs:Class, sh:NodeShape ;
-    sh:targetClass algo-ext:Snapshot ;
-    sh:message "A snapshot needs one source quantity, one held output quantity, and a valid initial or event-triggered sampling policy." ;
-    sh:property [ sh:path algo-ext:in ; sh:minCount 1 ; sh:maxCount 1 ; sh:nodeKind sh:BlankNodeOrIRI ; sh:class qudt:Quantity ] ;
-    sh:property [ sh:path algo-ext:out ; sh:minCount 1 ; sh:maxCount 1 ; sh:nodeKind sh:BlankNodeOrIRI ; sh:class qudt:Quantity ] ;
-    sh:property [ sh:path algo-ext:sampling ; sh:minCount 1 ; sh:maxCount 1 ; sh:nodeKind sh:IRI ; sh:in ( algo-ext:initial-sampling algo-ext:event-triggered-sampling ) ] ;
-    sh:property [ sh:path algo-ext:trigger ; sh:maxCount 1 ; sh:nodeKind sh:IRI ; sh:class time:Instant ] ;
-    sh:xone (
-        [
-            sh:property [ sh:path algo-ext:sampling ; sh:hasValue algo-ext:initial-sampling ] ;
-            sh:property [ sh:path algo-ext:trigger ; sh:maxCount 0 ]
-        ]
-        [
-            sh:property [ sh:path algo-ext:sampling ; sh:hasValue algo-ext:event-triggered-sampling ] ;
-            sh:property [ sh:path algo-ext:trigger ; sh:minCount 1 ]
-        ]
-    ) .
-
 # Force in, velocity out through a virtual mass-spring-damper.
 algo-ext:Admittance
     a rdfs:Class, sh:NodeShape ;

--- a/geometry/coordinates.json
+++ b/geometry/coordinates.json
@@ -43,6 +43,11 @@
         "coordinates": {
             "@id": "geom-coord:coordinates",
             "@container": "@list"
+        },
+
+        "has-coordinate-policy": {
+            "@id": "geom-coord:has-coordinate-policy",
+            "@type": "@id"
         }
     }
 }

--- a/geometry/geometry.shacl.ttl
+++ b/geometry/geometry.shacl.ttl
@@ -185,3 +185,13 @@ geom-coord:AnglesAlphaBetaGammaShape
     sh:minCount 1 ;
     sh:maxCount 1 ;
   ] .
+
+geom-coord:HasCoordinatePolicyShape
+  a sh:NodeShape ;
+  sh:targetSubjectsOf geom-coord:has-coordinate-policy ;
+  sh:message "A relation names at most one coordinate-selection policy, by IRI." ;
+  sh:property [
+    sh:path geom-coord:has-coordinate-policy ;
+    sh:nodeKind sh:IRI ;
+    sh:maxCount 1 ;
+  ] .

--- a/geometry/spatial-operators-extension.json
+++ b/geometry/spatial-operators-extension.json
@@ -47,6 +47,16 @@
             }
         },
 
+        "IncidentAngle": {
+            "@id": "geom-op-ext:IncidentAngle",
+            "@context": {
+                "in1": { "@id": "geom-op:in1", "@type": "@id" },
+                "in2": { "@id": "geom-op:in2", "@type": "@id" },
+                "angle": { "@id": "geom-op:angle", "@type": "@id" },
+                "gradient": { "@id": "geom-op-ext:gradient", "@type": "@id" }
+            }
+        },
+
         "ComposeOrientation": {
             "@id": "geom-op-ext:ComposeOrientation",
             "@context": {

--- a/geometry/spatial-operators-extension.json
+++ b/geometry/spatial-operators-extension.json
@@ -92,6 +92,61 @@
                 "direction": { "@id": "geom-op:direction", "@type": "@id" },
                 "along-speed": { "@id": "geom-op-ext:along-speed", "@type": "@id" }
             }
+        },
+
+        "PointPlaneDistance": {
+            "@id": "geom-op-ext:PointPlaneDistance",
+            "@context": {
+                "in1":       { "@id": "geom-op:in1", "@type": "@id" },
+                "in2":       { "@id": "geom-op:in2", "@type": "@id" },
+                "direction": { "@id": "geom-op:direction", "@type": "@id" },
+                "distance":  { "@id": "geom-op:distance", "@type": "@id" },
+                "gradient":  { "@id": "geom-op-ext:gradient", "@type": "@id" }
+            }
+        },
+
+        "PointLineDistance": {
+            "@id": "geom-op-ext:PointLineDistance",
+            "@context": {
+                "in1":       { "@id": "geom-op:in1", "@type": "@id" },
+                "in2":       { "@id": "geom-op:in2", "@type": "@id" },
+                "direction": { "@id": "geom-op:direction", "@type": "@id" },
+                "distance":  { "@id": "geom-op:distance", "@type": "@id" },
+                "gradient":  { "@id": "geom-op-ext:gradient", "@type": "@id" }
+            }
+        },
+
+        "PointOnLineProjection": {
+            "@id": "geom-op-ext:PointOnLineProjection",
+            "@context": {
+                "in1":       { "@id": "geom-op:in1", "@type": "@id" },
+                "in2":       { "@id": "geom-op:in2", "@type": "@id" },
+                "direction": { "@id": "geom-op:direction", "@type": "@id" },
+                "distance":  { "@id": "geom-op:distance", "@type": "@id" },
+                "gradient":  { "@id": "geom-op-ext:gradient", "@type": "@id" }
+            }
+        },
+
+        "LineLineDistance": {
+            "@id": "geom-op-ext:LineLineDistance",
+            "@context": {
+                "in1":      { "@id": "geom-op:in1", "@type": "@id" },
+                "in2":      { "@id": "geom-op:in2", "@type": "@id" },
+                "pose":     { "@id": "geom-op:pose", "@type": "@id" },
+                "distance": { "@id": "geom-op:distance", "@type": "@id" },
+                "gradient": { "@id": "geom-op-ext:gradient", "@type": "@id" }
+            }
+        },
+
+        "LineLineProjection": {
+            "@id": "geom-op-ext:LineLineProjection",
+            "@context": {
+                "in1":      { "@id": "geom-op:in1", "@type": "@id" },
+                "in2":      { "@id": "geom-op:in2", "@type": "@id" },
+                "pose":     { "@id": "geom-op:pose", "@type": "@id" },
+                "distance": { "@id": "geom-op:distance", "@type": "@id" },
+                "gradient": { "@id": "geom-op-ext:gradient", "@type": "@id" }
+            }
         }
     }
 }

--- a/geometry/spatial-operators-extension.json
+++ b/geometry/spatial-operators-extension.json
@@ -47,8 +47,8 @@
             }
         },
 
-        "IncidentAngle": {
-            "@id": "geom-op-ext:IncidentAngle",
+        "DirectionPlaneToAngularDistance": {
+            "@id": "geom-op-ext:DirectionPlaneToAngularDistance",
             "@context": {
                 "in1": { "@id": "geom-op:in1", "@type": "@id" },
                 "in2": { "@id": "geom-op:in2", "@type": "@id" },
@@ -104,8 +104,8 @@
             }
         },
 
-        "PointPlaneDistance": {
-            "@id": "geom-op-ext:PointPlaneDistance",
+        "PointPlaneToLinearDistance": {
+            "@id": "geom-op-ext:PointPlaneToLinearDistance",
             "@context": {
                 "in1":       { "@id": "geom-op:in1", "@type": "@id" },
                 "in2":       { "@id": "geom-op:in2", "@type": "@id" },
@@ -115,8 +115,8 @@
             }
         },
 
-        "PointLineDistance": {
-            "@id": "geom-op-ext:PointLineDistance",
+        "PointLineToLinearDistance": {
+            "@id": "geom-op-ext:PointLineToLinearDistance",
             "@context": {
                 "in1":       { "@id": "geom-op:in1", "@type": "@id" },
                 "in2":       { "@id": "geom-op:in2", "@type": "@id" },
@@ -137,8 +137,8 @@
             }
         },
 
-        "LineLineDistance": {
-            "@id": "geom-op-ext:LineLineDistance",
+        "LineLineToLinearDistance": {
+            "@id": "geom-op-ext:LineLineToLinearDistance",
             "@context": {
                 "in1":      { "@id": "geom-op:in1", "@type": "@id" },
                 "in2":      { "@id": "geom-op:in2", "@type": "@id" },
@@ -148,8 +148,8 @@
             }
         },
 
-        "LineLineProjection": {
-            "@id": "geom-op-ext:LineLineProjection",
+        "LineOnLineProjection": {
+            "@id": "geom-op-ext:LineOnLineProjection",
             "@context": {
                 "in1":      { "@id": "geom-op:in1", "@type": "@id" },
                 "in2":      { "@id": "geom-op:in2", "@type": "@id" },

--- a/geometry/spatial-operators-extension.json
+++ b/geometry/spatial-operators-extension.json
@@ -38,6 +38,15 @@
             }
         },
 
+        "AngleGradientFromDirections": {
+            "@id": "geom-op-ext:AngleGradientFromDirections",
+            "@context": {
+                "in1": { "@id": "geom-op:in1", "@type": "@id" },
+                "in2": { "@id": "geom-op:in2", "@type": "@id" },
+                "gradient": { "@id": "geom-op-ext:gradient", "@type": "@id" }
+            }
+        },
+
         "ComposeOrientation": {
             "@id": "geom-op-ext:ComposeOrientation",
             "@context": {

--- a/geometry/spatial-operators-extension.shacl.ttl
+++ b/geometry/spatial-operators-extension.shacl.ttl
@@ -126,6 +126,39 @@ geom-op-ext:AngleGradientFromDirections
         sh:class geom-coord:DirectionCoordinate
     ] .
 
+geom-op-ext:IncidentAngle
+    a rdfs:Class, sh:NodeShape ;
+    sh:targetClass geom-op-ext:IncidentAngle ;
+    sh:message "An incident-angle operator needs a versor direction and a plane-normal direction, and produces their signed angle and its gradient." ;
+    sh:property [
+        sh:path geom-op:in1 ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:class geom-coord:DirectionCoordinate
+    ] ;
+    sh:property [
+        sh:path geom-op:in2 ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:class geom-coord:DirectionCoordinate
+    ] ;
+    sh:property [
+        sh:path geom-op:angle ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:class qudt:Quantity ;
+        sh:node [ sh:property [ sh:path qudt:hasQuantityKind ; sh:hasValue qkind:PlaneAngle ] ]
+    ] ;
+    sh:property [
+        sh:path geom-op-ext:gradient ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:class geom-coord:DirectionCoordinate
+    ] .
+
 geom-op-ext:ComposeOrientation
     a rdfs:Class, sh:NodeShape ;
     sh:targetClass geom-op-ext:ComposeOrientation ;

--- a/geometry/spatial-operators-extension.shacl.ttl
+++ b/geometry/spatial-operators-extension.shacl.ttl
@@ -97,6 +97,35 @@ geom-op-ext:RotationVectorFromDirections
         sh:class geom-coord:VectorXYZ
     ] .
 
+# The direction along which the angle between two directions grows: normalize(in2 x in1).
+# Driving a controller along it moves in1 away from in2, so a controller reading the angle as
+# its error drives the angle the way it authored it.
+geom-op-ext:AngleGradientFromDirections
+    a rdfs:Class, sh:NodeShape ;
+    sh:targetClass geom-op-ext:AngleGradientFromDirections ;
+    sh:message "An angle-gradient-from-directions op needs two direction-coordinate inputs and one direction-coordinate gradient." ;
+    sh:property [
+        sh:path geom-op:in1 ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:class geom-coord:DirectionCoordinate
+    ] ;
+    sh:property [
+        sh:path geom-op:in2 ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:class geom-coord:DirectionCoordinate
+    ] ;
+    sh:property [
+        sh:path geom-op-ext:gradient ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:class geom-coord:DirectionCoordinate
+    ] .
+
 geom-op-ext:ComposeOrientation
     a rdfs:Class, sh:NodeShape ;
     sh:targetClass geom-op-ext:ComposeOrientation ;

--- a/geometry/spatial-operators-extension.shacl.ttl
+++ b/geometry/spatial-operators-extension.shacl.ttl
@@ -126,9 +126,9 @@ geom-op-ext:AngleGradientFromDirections
         sh:class geom-coord:DirectionCoordinate
     ] .
 
-geom-op-ext:IncidentAngle
+geom-op-ext:DirectionPlaneToAngularDistance
     a rdfs:Class, sh:NodeShape ;
-    sh:targetClass geom-op-ext:IncidentAngle ;
+    sh:targetClass geom-op-ext:DirectionPlaneToAngularDistance ;
     sh:message "An incident-angle operator needs a versor direction and a plane-normal direction, and produces their signed angle and its gradient." ;
     sh:property [
         sh:path geom-op:in1 ;
@@ -339,9 +339,9 @@ geom-op-ext:TwistToLinearVelocityAlong
 # primitive's normal/direction. Ops 4-5: in1/in2 are direction coordinates (line A, line B), and
 # pose is the PoseDiffEvaluator output between the two origins -- same role PoseToLinearDistance
 # uses for "the pose whose translation is the vector of interest". Deliberate asymmetry, not a bug.
-geom-op-ext:PointPlaneDistance
+geom-op-ext:PointPlaneToLinearDistance
     a rdfs:Class, sh:NodeShape ;
-    sh:targetClass geom-op-ext:PointPlaneDistance ;
+    sh:targetClass geom-op-ext:PointPlaneToLinearDistance ;
     sh:message "A point-plane distance needs two pose-coordinate inputs, a direction, and produces a signed distance and its gradient." ;
     sh:property [
         sh:path geom-op:in1 ;
@@ -379,9 +379,9 @@ geom-op-ext:PointPlaneDistance
         sh:class geom-coord:DirectionCoordinate
     ] .
 
-geom-op-ext:PointLineDistance
+geom-op-ext:PointLineToLinearDistance
     a rdfs:Class, sh:NodeShape ;
-    sh:targetClass geom-op-ext:PointLineDistance ;
+    sh:targetClass geom-op-ext:PointLineToLinearDistance ;
     sh:message "A point-line distance needs two pose-coordinate inputs, a direction, and produces an unsigned distance and its gradient." ;
     sh:property [
         sh:path geom-op:in1 ;
@@ -459,9 +459,9 @@ geom-op-ext:PointOnLineProjection
         sh:class geom-coord:DirectionCoordinate
     ] .
 
-geom-op-ext:LineLineDistance
+geom-op-ext:LineLineToLinearDistance
     a rdfs:Class, sh:NodeShape ;
-    sh:targetClass geom-op-ext:LineLineDistance ;
+    sh:targetClass geom-op-ext:LineLineToLinearDistance ;
     sh:message "A line-line distance needs two direction-coordinate inputs (line A, line B), the pose-difference between their origins, and produces a signed distance and its gradient." ;
     sh:property [
         sh:path geom-op:in1 ;
@@ -499,9 +499,9 @@ geom-op-ext:LineLineDistance
         sh:class geom-coord:DirectionCoordinate
     ] .
 
-geom-op-ext:LineLineProjection
+geom-op-ext:LineOnLineProjection
     a rdfs:Class, sh:NodeShape ;
-    sh:targetClass geom-op-ext:LineLineProjection ;
+    sh:targetClass geom-op-ext:LineOnLineProjection ;
     sh:message "A line-line projection needs two direction-coordinate inputs (line A, line B), the pose-difference between their origins, and produces a signed distance and its gradient." ;
     sh:property [
         sh:path geom-op:in1 ;

--- a/geometry/spatial-operators-extension.shacl.ttl
+++ b/geometry/spatial-operators-extension.shacl.ttl
@@ -302,6 +302,210 @@ geom-op-ext:TwistToLinearVelocityAlong
         sh:node [ sh:property [ sh:path qudt:hasQuantityKind ; sh:hasValue qkind:LinearVelocity ] ]
     ] .
 
+# Table IIa ops 1-3: in1/in2 are pose coordinates (point, primitive origin), direction is the
+# primitive's normal/direction. Ops 4-5: in1/in2 are direction coordinates (line A, line B), and
+# pose is the PoseDiffEvaluator output between the two origins -- same role PoseToLinearDistance
+# uses for "the pose whose translation is the vector of interest". Deliberate asymmetry, not a bug.
+geom-op-ext:PointPlaneDistance
+    a rdfs:Class, sh:NodeShape ;
+    sh:targetClass geom-op-ext:PointPlaneDistance ;
+    sh:message "A point-plane distance needs two pose-coordinate inputs, a direction, and produces a signed distance and its gradient." ;
+    sh:property [
+        sh:path geom-op:in1 ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:class geom-coord:PoseCoordinate
+    ] ;
+    sh:property [
+        sh:path geom-op:in2 ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:class geom-coord:PoseCoordinate
+    ] ;
+    sh:property [
+        sh:path geom-op:direction ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:class geom-coord:DirectionCoordinate
+    ] ;
+    sh:property [
+        sh:path geom-op:distance ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:class geom-coord:LinearDistanceCoordinate
+    ] ;
+    sh:property [
+        sh:path geom-op-ext:gradient ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:class geom-coord:DirectionCoordinate
+    ] .
+
+geom-op-ext:PointLineDistance
+    a rdfs:Class, sh:NodeShape ;
+    sh:targetClass geom-op-ext:PointLineDistance ;
+    sh:message "A point-line distance needs two pose-coordinate inputs, a direction, and produces an unsigned distance and its gradient." ;
+    sh:property [
+        sh:path geom-op:in1 ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:class geom-coord:PoseCoordinate
+    ] ;
+    sh:property [
+        sh:path geom-op:in2 ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:class geom-coord:PoseCoordinate
+    ] ;
+    sh:property [
+        sh:path geom-op:direction ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:class geom-coord:DirectionCoordinate
+    ] ;
+    sh:property [
+        sh:path geom-op:distance ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:class geom-coord:LinearDistanceCoordinate
+    ] ;
+    sh:property [
+        sh:path geom-op-ext:gradient ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:class geom-coord:DirectionCoordinate
+    ] .
+
+geom-op-ext:PointOnLineProjection
+    a rdfs:Class, sh:NodeShape ;
+    sh:targetClass geom-op-ext:PointOnLineProjection ;
+    sh:message "A point-on-line projection needs two pose-coordinate inputs, a direction, and produces a signed distance and its gradient." ;
+    sh:property [
+        sh:path geom-op:in1 ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:class geom-coord:PoseCoordinate
+    ] ;
+    sh:property [
+        sh:path geom-op:in2 ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:class geom-coord:PoseCoordinate
+    ] ;
+    sh:property [
+        sh:path geom-op:direction ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:class geom-coord:DirectionCoordinate
+    ] ;
+    sh:property [
+        sh:path geom-op:distance ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:class geom-coord:LinearDistanceCoordinate
+    ] ;
+    sh:property [
+        sh:path geom-op-ext:gradient ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:class geom-coord:DirectionCoordinate
+    ] .
+
+geom-op-ext:LineLineDistance
+    a rdfs:Class, sh:NodeShape ;
+    sh:targetClass geom-op-ext:LineLineDistance ;
+    sh:message "A line-line distance needs two direction-coordinate inputs (line A, line B), the pose-difference between their origins, and produces a signed distance and its gradient." ;
+    sh:property [
+        sh:path geom-op:in1 ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:class geom-coord:DirectionCoordinate
+    ] ;
+    sh:property [
+        sh:path geom-op:in2 ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:class geom-coord:DirectionCoordinate
+    ] ;
+    sh:property [
+        sh:path geom-op:pose ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:class geom-coord:PoseDifferenceCoordinate
+    ] ;
+    sh:property [
+        sh:path geom-op:distance ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:class geom-coord:LinearDistanceCoordinate
+    ] ;
+    sh:property [
+        sh:path geom-op-ext:gradient ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:class geom-coord:DirectionCoordinate
+    ] .
+
+geom-op-ext:LineLineProjection
+    a rdfs:Class, sh:NodeShape ;
+    sh:targetClass geom-op-ext:LineLineProjection ;
+    sh:message "A line-line projection needs two direction-coordinate inputs (line A, line B), the pose-difference between their origins, and produces a signed distance and its gradient." ;
+    sh:property [
+        sh:path geom-op:in1 ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:class geom-coord:DirectionCoordinate
+    ] ;
+    sh:property [
+        sh:path geom-op:in2 ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:class geom-coord:DirectionCoordinate
+    ] ;
+    sh:property [
+        sh:path geom-op:pose ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:class geom-coord:PoseDifferenceCoordinate
+    ] ;
+    sh:property [
+        sh:path geom-op:distance ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:class geom-coord:LinearDistanceCoordinate
+    ] ;
+    sh:property [
+        sh:path geom-op-ext:gradient ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:class geom-coord:DirectionCoordinate
+    ] .
+
 geom-op-ext:PathParameterShape
     a sh:NodeShape ;
     sh:message "A path parameter must be a dimensionless quantity whose value, when it has one, lies in the interval [0, 1]." ;

--- a/geometry/spatial-relations-extension.json
+++ b/geometry/spatial-relations-extension.json
@@ -3,6 +3,15 @@
         "@version": 1.1,
         "geom-rel-ext": "https://secorolab.github.io/metamodels/geometry/spatial-relations#",
 
-        "PoseDifference": "geom-rel-ext:PoseDifference"
+        "PoseDifference": "geom-rel-ext:PoseDifference",
+
+        "PointPlaneDistance": "geom-rel-ext:PointPlaneDistance",
+        "PointLineDistance": "geom-rel-ext:PointLineDistance",
+        "LineLineDistance": "geom-rel-ext:LineLineDistance",
+
+        "AngularDistance": "geom-rel-ext:AngularDistance",
+        "DirectionDirectionAngularDistance": "geom-rel-ext:DirectionDirectionAngularDistance",
+        "DirectionPlaneAngularDistance": "geom-rel-ext:DirectionPlaneAngularDistance",
+        "PlanePlaneAngularDistance": "geom-rel-ext:PlanePlaneAngularDistance"
     }
 }

--- a/geometry/spatial-relations-extension.shacl.ttl
+++ b/geometry/spatial-relations-extension.shacl.ttl
@@ -1,4 +1,5 @@
 @prefix geom: <https://comp-rob2b.github.io/metamodels/geometry/structural-entities#> .
+@prefix geom-ext: <https://secorolab.github.io/metamodels/geometry/structural-entities#> .
 @prefix geom-rel: <https://comp-rob2b.github.io/metamodels/geometry/spatial-relations#> .
 @prefix geom-rel-ext: <https://secorolab.github.io/metamodels/geometry/spatial-relations#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
@@ -20,4 +21,99 @@ geom-rel-ext:LinearDistanceShape
         sh:minCount 2 ;
         sh:maxCount 2 ;
         sh:nodeKind sh:BlankNodeOrIRI
+    ] .
+
+geom-rel-ext:PointPlaneDistance
+    a rdfs:Class, sh:NodeShape ;
+    sh:targetClass geom-rel-ext:PointPlaneDistance ;
+    sh:message "A point-plane distance must relate exactly one point and one plane." ;
+    sh:property [ sh:path geom-rel:between-entities ; sh:maxCount 2 ; sh:nodeKind sh:BlankNodeOrIRI ] ;
+    sh:property [
+        sh:path geom-rel:between-entities ;
+        sh:qualifiedValueShape [ sh:class geom:Point ] ;
+        sh:qualifiedMinCount 1 ;
+        sh:qualifiedMaxCount 1
+    ] ;
+    sh:property [
+        sh:path geom-rel:between-entities ;
+        sh:qualifiedValueShape [ sh:class geom-ext:Plane ] ;
+        sh:qualifiedMinCount 1 ;
+        sh:qualifiedMaxCount 1
+    ] .
+
+geom-rel-ext:PointLineDistance
+    a rdfs:Class, sh:NodeShape ;
+    sh:targetClass geom-rel-ext:PointLineDistance ;
+    sh:message "A point-line distance must relate exactly one point and one line." ;
+    sh:property [ sh:path geom-rel:between-entities ; sh:maxCount 2 ; sh:nodeKind sh:BlankNodeOrIRI ] ;
+    sh:property [
+        sh:path geom-rel:between-entities ;
+        sh:qualifiedValueShape [ sh:class geom:Point ] ;
+        sh:qualifiedMinCount 1 ;
+        sh:qualifiedMaxCount 1
+    ] ;
+    sh:property [
+        sh:path geom-rel:between-entities ;
+        sh:qualifiedValueShape [ sh:class geom-ext:Line ] ;
+        sh:qualifiedMinCount 1 ;
+        sh:qualifiedMaxCount 1
+    ] .
+
+geom-rel-ext:LineLineDistance
+    a rdfs:Class, sh:NodeShape ;
+    sh:targetClass geom-rel-ext:LineLineDistance ;
+    sh:message "A line-line distance must relate exactly two lines." ;
+    sh:property [
+        sh:path geom-rel:between-entities ;
+        sh:maxCount 2 ;
+        sh:class geom-ext:Line
+    ] .
+
+geom-rel-ext:AngularDistance
+    a rdfs:Class, sh:NodeShape ;
+    sh:targetClass geom-rel-ext:AngularDistance ;
+    sh:message "An angular distance must relate exactly two entities." ;
+    sh:property [
+        sh:path geom-rel:between-entities ;
+        sh:minCount 2 ;
+        sh:maxCount 2 ;
+        sh:nodeKind sh:BlankNodeOrIRI
+    ] .
+
+geom-rel-ext:DirectionDirectionAngularDistance
+    a rdfs:Class, sh:NodeShape ;
+    sh:targetClass geom-rel-ext:DirectionDirectionAngularDistance ;
+    sh:message "A direction-direction angular distance must relate exactly two unit vectors." ;
+    sh:property [
+        sh:path geom-rel:between-entities ;
+        sh:maxCount 2 ;
+        sh:class geom:UnitVector
+    ] .
+
+geom-rel-ext:DirectionPlaneAngularDistance
+    a rdfs:Class, sh:NodeShape ;
+    sh:targetClass geom-rel-ext:DirectionPlaneAngularDistance ;
+    sh:message "A direction-plane angular distance must relate exactly one unit vector and one plane." ;
+    sh:property [ sh:path geom-rel:between-entities ; sh:maxCount 2 ; sh:nodeKind sh:BlankNodeOrIRI ] ;
+    sh:property [
+        sh:path geom-rel:between-entities ;
+        sh:qualifiedValueShape [ sh:class geom:UnitVector ] ;
+        sh:qualifiedMinCount 1 ;
+        sh:qualifiedMaxCount 1
+    ] ;
+    sh:property [
+        sh:path geom-rel:between-entities ;
+        sh:qualifiedValueShape [ sh:class geom-ext:Plane ] ;
+        sh:qualifiedMinCount 1 ;
+        sh:qualifiedMaxCount 1
+    ] .
+
+geom-rel-ext:PlanePlaneAngularDistance
+    a rdfs:Class, sh:NodeShape ;
+    sh:targetClass geom-rel-ext:PlanePlaneAngularDistance ;
+    sh:message "A plane-plane angular distance must relate exactly two planes." ;
+    sh:property [
+        sh:path geom-rel:between-entities ;
+        sh:maxCount 2 ;
+        sh:class geom-ext:Plane
     ] .

--- a/geometry/structural-entities-extension.json
+++ b/geometry/structural-entities-extension.json
@@ -1,0 +1,23 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "geom": "https://comp-rob2b.github.io/metamodels/geometry/structural-entities#",
+        "geom-ext": "https://secorolab.github.io/metamodels/geometry/structural-entities#",
+
+        "Line": {
+            "@id": "geom-ext:Line",
+            "@context": {
+                "origin": { "@id": "geom:origin", "@type": "@id" },
+                "direction": { "@id": "geom-ext:direction", "@type": "@id" }
+            }
+        },
+
+        "Plane": {
+            "@id": "geom-ext:Plane",
+            "@context": {
+                "origin": { "@id": "geom:origin", "@type": "@id" },
+                "normal": { "@id": "geom-ext:normal", "@type": "@id" }
+            }
+        }
+    }
+}

--- a/geometry/structural-entities-extension.shacl.ttl
+++ b/geometry/structural-entities-extension.shacl.ttl
@@ -1,0 +1,38 @@
+@prefix geom:     <https://comp-rob2b.github.io/metamodels/geometry/structural-entities#> .
+@prefix geom-ext: <https://secorolab.github.io/metamodels/geometry/structural-entities#> .
+@prefix rdfs:     <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh:       <http://www.w3.org/ns/shacl#> .
+
+geom-ext:Line
+    a rdfs:Class, sh:NodeShape ;
+    sh:targetClass geom-ext:Line ;
+    sh:message "A line needs one origin point and one unit direction." ;
+    sh:property [
+        sh:path geom:origin ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:class geom:Point
+    ] ;
+    sh:property [
+        sh:path geom-ext:direction ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:class geom:UnitVector
+    ] .
+
+geom-ext:Plane
+    a rdfs:Class, sh:NodeShape ;
+    sh:targetClass geom-ext:Plane ;
+    sh:message "A plane needs one origin point and one unit normal." ;
+    sh:property [
+        sh:path geom:origin ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:class geom:Point
+    ] ;
+    sh:property [
+        sh:path geom-ext:normal ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:class geom:UnitVector
+    ] .


### PR DESCRIPTION
The relation and operator names here follow the taxonomy in ([10.1109/LRA.2015.2506119](https://ieeexplore.ieee.org/document/7348670)):

> G. Borghesan, E. Scioni, A. Kheddar, H. Bruyninckx, "Introducing Geometric
> Constraint Expressions into Robot Constrained Motion Specification and
> Control", IEEE Robotics and Automation Letters, 1(2):1140–1147, 2016.

Its Table II lists the constraint expressions between geometric primitives —
IIa the linear distances, IIb the angular ones — and this adds the vocabulary
for the rows we support.

**Primitives** (`geometry/structural-entities-extension`): `Line`, from an
origin and a direction, and `Plane`, from an origin and a normal. Table II is
written over point/line/plane, and only the point existed.

**Relations** (`geometry/spatial-relations-extension`): `PointPlaneDistance`,
`PointLineDistance` and `LineLineDistance` for Table IIa; `AngularDistance`
with its `DirectionDirection`, `DirectionPlane` and `PlanePlane` forms for
Table IIb. Each shape says which primitives it relates — a point-plane
distance relates exactly one point and one plane, a line-line distance exactly
two lines — so a malformed relation fails validation rather than code
generation.

**Operators** (`geometry/spatial-operators-extension`) that compute those
coordinates: `PointPlaneToLinearDistance`, `PointLineToLinearDistance`,
`LineLineToLinearDistance`, `DirectionPlaneToAngularDistance`,
`AngleGradientFromDirections`, and the projections `PointOnLineProjection` and
`LineOnLineProjection`.

An operator is named `<inputs>To<Relation>` when its output is a relation
coordinate, so the operator never collides with the relation it produces. The
two projections keep a domain name because a projection is not a relation
coordinate.


## Retiring the snapshot operator

`algo-ext:Snapshot` said *when* a value is captured, in a vocabulary of its own — an `initial` or
`event-triggered` sampling policy plus a trigger instant. Every part is said better elsewhere: a
captured value is an observation of the relation it samples (secorolab/metamodels#70), and when it
was captured is a time constraint against a coordinator event.

The sampling policy was the tell. `initial-sampling` meant "when my owning motion starts" — a
coordination decision stated inside the computation model, when a motion has no business knowing
when it starts. Naming the event leaves that with the coordinator, and once it is named the enum has
nothing left to say: a live value is the same construct sampled on every cycle, and re-entry needs
no expression because the event fires again.

`algo-ext:in` and `out` are declared per operator, so the remaining eight keep theirs.

Producers still emit these terms until the motion-spec emitter and consumer are updated. Nothing
breaks in the interim — the emitters build IRIs from a `Namespace` rather than the context — but the
triples are undefined until then.
