### PR TITLE
A home for the observation and time-constraint vocabularies

### DIFF
--- a/observation.json
+++ b/observation.json
@@ -1,0 +1,33 @@
+{
+    "@context": {
+        "xsd": "http://www.w3.org/2001/XMLSchema#",
+        "obs": "https://secorolab.github.io/metamodels/observation#",
+        "sens": "https://secorolab.github.io/metamodels/robot/sensors#",
+
+        "ObservationProvider": { "@id": "obs:ObservationProvider" },
+        "has-provider": { "@id": "obs:has-provider", "@type": "@id" },
+
+        "ObservationPolicy": { "@id": "obs:ObservationPolicy" },
+        "DirectTrinaryPolicy": { "@id": "obs:DirectTrinaryPolicy" },
+        "EvaluatedObservationPolicy": { "@id": "obs:EvaluatedObservationPolicy" },
+        "has-policy": { "@id": "obs:has-policy", "@type": "@id" },
+        "time-extractor": { "@id": "obs:time-extractor", "@type": "@id" },
+        "entity-mapper": { "@id": "obs:entity-mapper", "@type": "@id" },
+        "has-evaluator": { "@id": "obs:has-evaluator", "@type": "@id" },
+        "LinearDistanceEvaluator": { "@id": "obs:LinearDistanceEvaluator" },
+
+        "Observation": { "@id": "obs:Observation" },
+        "has-observation": { "@id": "obs:has-observation", "@type": "@id" },
+        "observes-target": { "@id": "obs:observes-target", "@type": "@id" },
+
+        "PoseProvider": { "@id": "obs:PoseProvider" },
+        "VelocityTwistProvider": { "@id": "obs:VelocityTwistProvider" },
+        "AccelerationTwistProvider": { "@id": "obs:AccelerationTwistProvider" },
+        "WrenchProvider": { "@id": "obs:WrenchProvider" },
+        "JointPositionProvider": { "@id": "obs:JointPositionProvider" },
+        "JointVelocityProvider": { "@id": "obs:JointVelocityProvider" },
+        "JointAccelerationProvider": { "@id": "obs:JointAccelerationProvider" },
+        "JointForceProvider": { "@id": "obs:JointForceProvider" },
+        "update-rate": { "@id": "sens:update-rate", "@type": "@id" }
+    }
+}

--- a/observation.shacl.ttl
+++ b/observation.shacl.ttl
@@ -1,0 +1,197 @@
+# SPDX-License-Identifier: MPL-2.0
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix bdd: <https://secorolab.github.io/metamodels/acceptance-criteria/bdd#> .
+@prefix env: <https://secorolab.github.io/metamodels/environment#> .
+@prefix agn: <https://secorolab.github.io/metamodels/agent#> .
+@prefix obs: <https://secorolab.github.io/metamodels/observation#> .
+@prefix py: <https://secorolab.github.io/metamodels/languages/python#> .
+@prefix ros: <https://index.ros.org/p/> .
+@prefix cstr-ext: <https://secorolab.github.io/metamodels/task/constraint#> .
+@prefix sens: <https://secorolab.github.io/metamodels/robot/sensors#> .
+@prefix sosa: <http://www.w3.org/ns/sosa/> .
+@prefix qudt: <http://qudt.org/schema/qudt/> .
+@prefix qudt-quant: <http://qudt.org/vocab/quantitykind/> .
+@prefix geom-rel: <https://comp-rob2b.github.io/metamodels/geometry/spatial-relations#> .
+
+obs:ObservationShape
+    a sh:NodeShape ;
+    sh:targetClass obs:Observation ;
+    sh:property [
+        sh:path obs:has-provider ;
+        sh:class obs:ObservationProvider ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+    ] ;
+    sh:property [
+        sh:path obs:observes-target ;
+        sh:nodeKind sh:IRI ;
+        sh:node [
+            sh:or (
+                [ sh:class bdd:ScenarioVariable ]
+                [ sh:class env:Object ]
+                [ sh:class env:Workspace ]
+                [ sh:class agn:Agent ]
+            )
+        ] ;
+        sh:maxCount 1 ;
+    ] ;
+    sh:property [
+        sh:path obs:time-extractor ;
+        sh:class py:ModuleAttribute ;
+        sh:maxCount 1 ;
+    ] ;
+    sh:property [
+        sh:path obs:entity-mapper ;
+        sh:class py:ModuleAttribute ;
+        sh:maxCount 1 ;
+    ] ;
+    sh:sparql [
+        sh:message "A targeted observation requires an entity mapper." ;
+        sh:select """
+            PREFIX obs: <https://secorolab.github.io/metamodels/observation#>
+            SELECT $this
+            WHERE {
+                $this obs:observes-target ?target .
+                FILTER NOT EXISTS { $this obs:entity-mapper ?mapper }
+            }
+        """ ;
+    ] .
+
+obs:ObservationPolicyShape
+    a sh:NodeShape ;
+    sh:targetClass obs:ObservationPolicy ;
+    sh:xone (
+        [ sh:class obs:DirectTrinaryPolicy ]
+        [ sh:class obs:EvaluatedObservationPolicy ]
+    ) .
+
+obs:DirectTrinaryPolicyShape
+    a sh:NodeShape ;
+    sh:targetClass obs:DirectTrinaryPolicy ;
+    sh:class obs:ObservationPolicy ;
+    sh:property [ sh:path obs:has-observation ; sh:maxCount 0 ] ;
+    sh:property [ sh:path obs:time-extractor ; sh:maxCount 0 ] ;
+    sh:property [ sh:path obs:entity-mapper ; sh:maxCount 0 ] ;
+    sh:property [ sh:path obs:has-evaluator ; sh:maxCount 0 ] .
+
+obs:EvaluatedObservationPolicyShape
+    a sh:NodeShape ;
+    sh:targetClass obs:EvaluatedObservationPolicy ;
+    sh:class obs:ObservationPolicy ;
+    sh:property [
+        sh:path obs:has-observation ;
+        sh:class obs:Observation ;
+        sh:minCount 1 ;
+    ] ;
+    sh:property [ sh:path obs:time-extractor ; sh:maxCount 0 ] ;
+    sh:property [ sh:path obs:entity-mapper ; sh:maxCount 0 ] ;
+    sh:property [
+        sh:path obs:has-evaluator ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:node obs:EvaluatorShape ;
+    ] .
+
+obs:EvaluatorShape
+    a sh:NodeShape ;
+    sh:or (
+        [ sh:class py:ModuleAttribute ]
+        [ sh:class obs:LinearDistanceEvaluator ]
+    ) .
+
+obs:LinearDistanceEvaluatorShape
+    a sh:NodeShape ;
+    sh:targetClass obs:LinearDistanceEvaluator ;
+    sh:class geom-rel:LinearDistance ;
+    sh:property [
+        sh:path geom-rel:between-entities ;
+        sh:class obs:Observation ;
+        sh:minCount 2 ;
+        sh:maxCount 2 ;
+    ] ;
+    sh:property [
+        sh:path cstr-ext:has-constraint ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+    ] ;
+    sh:sparql [
+        sh:message "A linear evaluator can only reference observations of its policy." ;
+        sh:select """
+            PREFIX obs: <https://secorolab.github.io/metamodels/observation#>
+            PREFIX geom-rel: <https://comp-rob2b.github.io/metamodels/geometry/spatial-relations#>
+            SELECT $this
+            WHERE {
+                ?policy obs:has-evaluator $this .
+                $this geom-rel:between-entities ?observation .
+                FILTER NOT EXISTS { ?policy obs:has-observation ?observation }
+            }
+        """ ;
+    ] .
+
+# A provider is named after the quantity it yields, which is the cheapest way to ask whether an
+# observation carries a pose. Which wire it arrives on is the provider's own type, not this.
+obs:QuantityProviderShape
+    a sh:NodeShape ;
+    sh:targetClass
+        obs:PoseProvider ,
+        obs:VelocityTwistProvider ,
+        obs:AccelerationTwistProvider ,
+        obs:WrenchProvider ,
+        obs:JointPositionProvider ,
+        obs:JointVelocityProvider ,
+        obs:JointAccelerationProvider ,
+        obs:JointForceProvider ;
+    sh:class obs:ObservationProvider .
+
+ros:TopicProviderShape
+    a sh:NodeShape ;
+    sh:targetClass ros:Topic ;
+    sh:property [
+        sh:path ros:channel-name ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+    ] ;
+    sh:property [
+        sh:path ros:type-name ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+    ] .
+
+ros:SimulationEntityStateProviderShape
+    a sh:NodeShape ;
+    sh:targetClass ros:SimulationEntityStateProvider ;
+    sh:class obs:PoseProvider ;
+    sh:class sosa:Sensor ;
+    sh:property [
+        sh:path sens:update-rate ;
+        sh:node sens:FrequencyQuantityShape ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+    ] .
+
+
+sens:FrequencyQuantityShape
+    a sh:NodeShape ;
+    sh:class qudt:Quantity ;
+    sh:property [
+        sh:path qudt:hasQuantityKind ;
+        sh:hasValue qudt-quant:Frequency ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+    ] ;
+    sh:property [
+        sh:path qudt:unit ;
+        sh:nodeKind sh:IRI ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+    ] ;
+    sh:property [
+        sh:path qudt:value ;
+        sh:nodeKind sh:Literal ;
+        sh:minExclusive 0.0 ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+    ] .

--- a/ssn.json
+++ b/ssn.json
@@ -3,6 +3,7 @@
         "@version": 1.1,
         "sosa": "http://www.w3.org/ns/sosa/",
         "ssn": "http://www.w3.org/ns/ssn/",
+        "xsd": "http://www.w3.org/2001/XMLSchema#",
 
         "System": "ssn:System",
         "Deployment": "ssn:Deployment",
@@ -46,6 +47,22 @@
             "@id": "sosa:hasFeatureOfInterest",
             "@type": "@id",
             "@container": "@set"
+        },
+        "has-result": {
+            "@id": "sosa:hasResult",
+            "@type": "@id"
+        },
+        "result-time": {
+            "@id": "sosa:resultTime",
+            "@type": "xsd:dateTime"
+        },
+        "phenomenon-time": {
+            "@id": "sosa:phenomenonTime",
+            "@type": "@id"
+        },
+        "used-procedure": {
+            "@id": "sosa:usedProcedure",
+            "@type": "@id"
         }
     }
 }

--- a/time-constraint.json
+++ b/time-constraint.json
@@ -1,0 +1,17 @@
+{
+    "@context": {
+        "xsd": "http://www.w3.org/2001/XMLSchema#",
+        "tc": "https://secorolab.github.io/metamodels/time-constraint#",
+        "time": "http://www.w3.org/2006/time#",
+
+        "TimeConstraint": { "@id": "tc:TimeConstraint" },
+        "of-constraint": { "@id": "tc:of-constraint", "@type": "@id" },
+
+        "BeforeEventConstraint": { "@id": "tc:BeforeEventConstraint" },
+        "AfterEventConstraint": { "@id": "tc:AfterEventConstraint" },
+        "DuringEventsConstraint": { "@id": "tc:DuringEventsConstraint" },
+        "before-event": { "@id": "tc:before-event", "@type": "@id" },
+        "after-event": { "@id": "tc:after-event", "@type": "@id" },
+        "horizon-seconds": { "@id": "tc:horizon-seconds", "@type": "xsd:float" }
+    }
+}

--- a/time-constraint.shacl.ttl
+++ b/time-constraint.shacl.ttl
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier:  MPL-2.0
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix time: <http://www.w3.org/2006/time#> .
+@prefix tc: <https://secorolab.github.io/metamodels/time-constraint#> .
+
+tc:BeforeEventShape
+  a sh:PropertyShape ;
+  sh:description ":before-event must link to exactly 1 time:Instant" ;
+  sh:path tc:before-event ;
+  sh:class time:Instant ;
+  sh:nodeKind sh:IRI ;
+  sh:minCount 1 ;
+  sh:maxCount 1 .
+
+tc:AfterEventShape
+  a sh:PropertyShape ;
+  sh:description ":after-event must link to exactly 1 time:Instant" ;
+  sh:path tc:after-event ;
+  sh:class time:Instant ;
+  sh:nodeKind sh:IRI ;
+  sh:minCount 1 ;
+  sh:maxCount 1 .
+
+tc:BeforeEventConstraintShape
+  a sh:NodeShape ;
+  sh:targetClass tc:BeforeEventConstraint ;
+  sh:property tc:BeforeEventShape ;
+  sh:and (
+    [ sh:class tc:BeforeEventConstraint ]
+    [ sh:class tc:TimeConstraint ]
+  ) .
+
+tc:AfterEventConstraintShape
+  a sh:NodeShape ;
+  sh:targetClass tc:AfterEventConstraint ;
+  sh:property tc:AfterEventShape ;
+  sh:and (
+    [ sh:class tc:AfterEventConstraint ]
+    [ sh:class tc:TimeConstraint ]
+  ) .
+
+tc:DuringEventsConstraintShape
+  a sh:NodeShape ;
+  sh:targetClass tc:DuringEventsConstraint ;
+  sh:property tc:BeforeEventShape ;
+  sh:property tc:AfterEventShape ;
+  sh:and (
+    [ sh:class tc:DuringEventsConstraint ]
+    [ sh:class tc:TimeConstraint ]
+  ) .


### PR DESCRIPTION
Both lived in the `acceptance-criteria/bdd` submodule and neither is specific to acceptance
criteria — `motion-spec` already read `obs:` in four places, reaching in for it. Deletion half is
secorolab/metamodels-bdd#5; **this lands first**, or the submodule bump leaves `bdd.shacl.ttl`
resolving `tc:TimeConstraint` against nothing.

`time` becomes `time-constraint`, namespace and all: the old name collided with `time.json` binding
the same `time:` prefix to OWL-Time.

**`time:Event` is dropped**, the one term that does not survive. Never defined — no shape, no
subclass, no properties — and its only use was the `sh:class` on the before/after shapes. Events are
`owl-time:Instant`, which the event loop and the FSMs already emit, so the shapes take that
directly. `rdfs:subClassOf` would not serve: `sh:class` does no subclass reasoning and pyshacl runs
no entailment.

**Providers are named after what they yield, not how they arrive.** `obs:PoseProvider` loses its
`sh:or` whitelist over `ros:Topic` and `ros:SimulationEntityStateProvider`, which made deployment
detail part of the vocabulary and left no way to declare a pose computed by forward kinematics in a
control loop. It gains siblings for the rest of what a motion observes — velocity and acceleration
twists, wrench, and joint position/velocity/acceleration/force — each mirroring a class that already
exists (`geom-rel:VelocityTwist`, `dyn-ent:Wrench`, `kc-stat:JointPosition`, …). One shape carries
all eight targets.

**`obs:time-extractor` is no longer mandatory.** It pulls a stamp out of a ROS message; an
observation from a compiled control loop has neither, its stamp being the tick.

`AfterEventConstraintShape` read `a sh:NodeShpe`, so it was never registered and the class had never
been validated by anything. Fixed, and verified by making it fail. `ssn.json` gains four standard
SOSA terms — `hasResult`, `resultTime`, `phenomenonTime`, `usedProcedure`.

Breaking by design; downstream notes on secorolab/metamodels-bdd#5.
